### PR TITLE
feat(llm): 동시성 풀 + ModelSelector + dispatch concurrencyHint (orchestration Phase 1)

### DIFF
--- a/scripts/lib/agent/team-builder.js
+++ b/scripts/lib/agent/team-builder.js
@@ -4,6 +4,9 @@ import { getDefaultsForComplexity } from './complexity-analyzer.js';
 import { config } from '../core/config.js';
 import { LazyCache } from '../core/cache.js';
 import { pluginRoot } from '../core/app-paths.js';
+import { createModelSelector } from '../llm/model-selector.js';
+
+const defaultSelector = createModelSelector('default');
 
 const CATALOG_PATH = resolve(pluginRoot(), 'presets', 'team-roles', 'catalog.json');
 const PROJECT_TYPES_PATH = resolve(pluginRoot(), 'presets', 'project-types.json');
@@ -128,27 +131,15 @@ export async function buildTeam(roleIds, personalityChoices = {}, options = {}) 
 
 /**
  * 역할의 카테고리와 복잡도에 따라 적절한 모델을 결정한다.
+ * 내부적으로 ModelSelector('default')에 위임. 정책 교체가 필요하면
+ * `createModelSelector`를 직접 사용하라.
  * @param {object} role - 카탈로그 역할 정보 (role.model, role.category)
  * @param {string} [complexity] - 복잡도 ('simple' | 'medium' | 'complex')
  * @param {string} [taskType] - 태스크 유형 (예: 'architecture-review')
  * @returns {string} 모델 이름
  */
 export function resolveModel(role, complexity, taskType) {
-  if (!complexity) return role.model;
-
-  const defaults = getDefaultsForComplexity(complexity);
-  const modelTiers = defaults.modelTiers;
-  if (!modelTiers) return role.model;
-
-  const category = role.category || 'engineering';
-  let model = modelTiers[category] || role.model;
-
-  // architecture-review + complex → opus 업그레이드
-  if (taskType === 'architecture-review' && complexity === 'complex') {
-    model = 'opus';
-  }
-
-  return model;
+  return defaultSelector.selectModel({ role, complexity, taskType });
 }
 
 /**

--- a/scripts/lib/core/config.js
+++ b/scripts/lib/core/config.js
@@ -44,6 +44,20 @@ export const config = Object.freeze({
     maxRetries: 3,
     maxPromptSectionLength: 3000,
   }),
+  llmPool: Object.freeze({
+    maxConcurrent: 8,
+    perProvider: Object.freeze({
+      claude: 5,
+      openai: 5,
+      // gemini-bridge.js는 spawnSync(블로킹). 비동기화 전까지 직렬 처리.
+      gemini: 1,
+    }),
+    backpressure: Object.freeze({
+      halveOnRateLimit: true,
+      minConcurrent: 1,
+      recoveryMs: 60_000,
+    }),
+  }),
   review: Object.freeze({
     minReviewers: 2,
     maxReviewers: 3,

--- a/scripts/lib/engine/dispatch-plan-generator.js
+++ b/scripts/lib/engine/dispatch-plan-generator.js
@@ -97,6 +97,12 @@ export function buildDiscussionDispatchPlan(project, team, context = {}) {
       threshold: config.convergence.threshold,
       maxRounds,
     },
+    concurrencyHint: {
+      allTiersParallel: true,
+      reviewsParallel: true,
+      reasoning:
+        'buildAgentAnalysisPrompt가 priorTierOutputs를 미사용하므로 모든 tier 에이전트를 동시에 실행해도 안전하다. 리뷰 단계도 독립적이므로 병렬 실행한다. LLM 호출은 llm-pool에서 동시성/backpressure 제어.',
+    },
   };
 }
 
@@ -133,6 +139,11 @@ export function buildExecutionDispatchPlan(project, tasks, team, context = {}) {
       return {
         type: 'execute',
         phase: phase.phase,
+        concurrencyHint: {
+          tasksParallel: true,
+          reasoning:
+            '같은 phase 내 태스크는 의존이 없도록 분배되었다. 병렬 실행 안전. LLM 동시성은 llm-pool이 제어.',
+        },
         tasks: phase.tasks.map((task) => {
           const member = teamMap[task.assignee];
           const codeTask = isCodeTask(task);
@@ -168,6 +179,11 @@ export function buildExecutionDispatchPlan(project, tasks, team, context = {}) {
     return {
       type: 'review',
       phase: phase.phase,
+      concurrencyHint: {
+        reviewersParallel: true,
+        reasoning:
+          '리뷰어는 독립적으로 평가한다. 병렬 실행 안전. cross-model-strategy 사용 시 자동 분산.',
+      },
       tasks: phase.tasks.map((task) => {
         const reviewers = selectReviewers(task, team);
         return {

--- a/scripts/lib/llm/llm-pool.js
+++ b/scripts/lib/llm/llm-pool.js
@@ -1,0 +1,175 @@
+/**
+ * llm-pool — LLM 호출 동시성 풀 + 적응형 backpressure
+ *
+ * 글로벌 동시성 한도와 프로바이더별 한도를 함께 적용한다.
+ * 429(rate limit) 신호 시 effective limit를 절반으로 줄였다가
+ * cooldown 이후 자동 회복한다.
+ *
+ * 외부 의존성 0. callLLM 진입점에서 wrap 사용.
+ */
+
+const DEFAULTS = {
+  maxConcurrent: 10,
+  perProvider: {},
+  backpressure: {
+    halveOnRateLimit: true,
+    minConcurrent: 1,
+    recoveryMs: 60_000,
+  },
+};
+
+/**
+ * LLM 동시성 풀을 생성한다.
+ *
+ * @param {object} [options]
+ * @param {number} [options.maxConcurrent=10] - 글로벌 최대 동시 실행 수
+ * @param {Object<string, number>} [options.perProvider={}] - 프로바이더별 최대 동시 실행 수
+ * @param {object} [options.backpressure]
+ * @param {boolean} [options.backpressure.halveOnRateLimit=true] - 429 시 effective 한도 절반
+ * @param {number} [options.backpressure.minConcurrent=1] - 최소 effective 한도
+ * @param {number} [options.backpressure.recoveryMs=60000] - 마지막 429 후 회복까지 대기
+ * @returns {{
+ *   run: (provider: string, fn: () => Promise<any>) => Promise<any>,
+ *   signalRateLimit: (provider: string) => void,
+ *   getEffectiveLimit: (provider: string) => number,
+ *   getStats: () => object,
+ * }}
+ */
+export function createLLMPool(options = {}) {
+  const maxConcurrent = options.maxConcurrent ?? DEFAULTS.maxConcurrent;
+  const perProviderConfig = options.perProvider ?? DEFAULTS.perProvider;
+  const bp = { ...DEFAULTS.backpressure, ...(options.backpressure || {}) };
+
+  const state = {
+    globalInFlight: 0,
+    perProviderInFlight: new Map(),
+    perProviderEffective: new Map(),
+    perProviderLastRateLimit: new Map(),
+    waiters: [],
+    stats: {
+      totalRuns: 0,
+      totalErrors: 0,
+      byProvider: new Map(),
+    },
+  };
+
+  function configuredLimit(provider) {
+    return perProviderConfig[provider] ?? maxConcurrent;
+  }
+
+  function maybeRecover(provider) {
+    const reduced = state.perProviderEffective.get(provider);
+    if (reduced === undefined) return;
+    const lastSignal = state.perProviderLastRateLimit.get(provider) || 0;
+    if (bp.recoveryMs > 0 && Date.now() - lastSignal >= bp.recoveryMs) {
+      state.perProviderEffective.delete(provider);
+      state.perProviderLastRateLimit.delete(provider);
+    }
+  }
+
+  function effectiveLimit(provider) {
+    maybeRecover(provider);
+    const reduced = state.perProviderEffective.get(provider);
+    return reduced ?? configuredLimit(provider);
+  }
+
+  function getInFlight(provider) {
+    return state.perProviderInFlight.get(provider) || 0;
+  }
+
+  function canAcquire(provider) {
+    if (state.globalInFlight >= maxConcurrent) return false;
+    return getInFlight(provider) < effectiveLimit(provider);
+  }
+
+  function acquire(provider) {
+    state.globalInFlight++;
+    state.perProviderInFlight.set(provider, getInFlight(provider) + 1);
+  }
+
+  function release(provider) {
+    state.globalInFlight = Math.max(0, state.globalInFlight - 1);
+    state.perProviderInFlight.set(provider, Math.max(0, getInFlight(provider) - 1));
+    drain();
+  }
+
+  function drain() {
+    // backpressure 회복 또는 슬롯 여유로 동시에 여러 waiter가 가용해질 수 있다.
+    // 한 번의 drain에서 가능한 모두 깨운다.
+    let i = 0;
+    while (i < state.waiters.length) {
+      const waiter = state.waiters[i];
+      if (canAcquire(waiter.provider)) {
+        state.waiters.splice(i, 1);
+        acquire(waiter.provider);
+        waiter.resolve();
+      } else {
+        i++;
+      }
+    }
+  }
+
+  function recordRun(provider) {
+    state.stats.totalRuns++;
+    const byP = state.stats.byProvider.get(provider) || { runs: 0, errors: 0 };
+    byP.runs++;
+    state.stats.byProvider.set(provider, byP);
+  }
+
+  function recordError(provider) {
+    state.stats.totalErrors++;
+    const byP = state.stats.byProvider.get(provider) || { runs: 0, errors: 0 };
+    byP.errors++;
+    state.stats.byProvider.set(provider, byP);
+  }
+
+  async function waitForSlot(provider) {
+    if (canAcquire(provider)) {
+      acquire(provider);
+      return;
+    }
+    await new Promise((resolve) => {
+      state.waiters.push({ provider, resolve });
+    });
+  }
+
+  return {
+    async run(provider, fn) {
+      await waitForSlot(provider);
+      recordRun(provider);
+      try {
+        return await fn();
+      } catch (err) {
+        recordError(provider);
+        throw err;
+      } finally {
+        release(provider);
+      }
+    },
+
+    signalRateLimit(provider) {
+      if (!bp.halveOnRateLimit) return;
+      const current = effectiveLimit(provider);
+      const next = Math.max(bp.minConcurrent, Math.floor(current / 2));
+      state.perProviderEffective.set(provider, next);
+      state.perProviderLastRateLimit.set(provider, Date.now());
+    },
+
+    getEffectiveLimit(provider) {
+      return effectiveLimit(provider);
+    },
+
+    getStats() {
+      const byProvider = {};
+      for (const [k, v] of state.stats.byProvider) {
+        byProvider[k] = { ...v };
+      }
+      return {
+        totalRuns: state.stats.totalRuns,
+        totalErrors: state.stats.totalErrors,
+        inFlight: state.globalInFlight,
+        byProvider,
+      };
+    },
+  };
+}

--- a/scripts/lib/llm/llm-provider.js
+++ b/scripts/lib/llm/llm-provider.js
@@ -8,6 +8,7 @@
 
 import { loadAuth } from './auth-manager.js';
 import { callGeminiCli } from './gemini-bridge.js';
+import { createLLMPool } from './llm-pool.js';
 import { config } from '../core/config.js';
 import { AppError, inputError, notFoundError } from '../core/validators.js';
 import { truncateText } from '../core/text-utils.js';
@@ -40,6 +41,18 @@ const DEFAULT_MODELS = {
 /** 지원 프로바이더 목록 */
 export const SUPPORTED_PROVIDERS = ['claude', 'openai', 'gemini'];
 
+/** 글로벌 LLM 동시성 풀 (config.llmPool 정책). 모든 callLLM이 통과한다. */
+const llmPool = createLLMPool({
+  maxConcurrent: config.llmPool.maxConcurrent,
+  perProvider: { ...config.llmPool.perProvider },
+  backpressure: { ...config.llmPool.backpressure },
+});
+
+/** 테스트/관측용 풀 통계 — getStats() 노출. */
+export function getLLMPoolStats() {
+  return llmPool.getStats();
+}
+
 /**
  * 통합 LLM 호출 인터페이스.
  * @param {string} providerId - 'claude' | 'openai' | 'gemini'
@@ -58,6 +71,10 @@ export async function callLLM(providerId, prompt, options = {}) {
     throw notFoundError(`${providerId} 인증 정보가 없습니다. 먼저 connect 명령으로 인증하세요.`);
   }
 
+  return llmPool.run(providerId, () => _executeLLMCall(providerId, prompt, options, auth));
+}
+
+async function _executeLLMCall(providerId, prompt, options, auth) {
   // Gemini CLI 인증일 때 서브프로세스 경로로 분기
   if (providerId === 'gemini' && auth.type === 'cli') {
     const model = options.model || DEFAULT_MODELS.gemini;
@@ -70,6 +87,7 @@ export async function callLLM(providerId, prompt, options = {}) {
   const headers = buildAuthHeaders(providerId, auth);
   const maxRetries = options.maxRetries ?? config.llm.maxRetries;
   let lastError;
+  let rateLimitSignaled = false;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
@@ -88,6 +106,12 @@ export async function callLLM(providerId, prompt, options = {}) {
           'SYSTEM_ERROR',
         );
         err.statusCode = response.status;
+
+        // 429: 호출당 1회만 풀에 backpressure 신호 — 재시도마다 halve되면 과도한 감속
+        if (response.status === 429 && !rateLimitSignaled) {
+          llmPool.signalRateLimit(providerId);
+          rateLimitSignaled = true;
+        }
 
         // 재시도 불가 상태 코드(4xx, 429 제외)는 즉시 throw
         if (!RETRYABLE_STATUS_CODES.has(response.status)) {

--- a/scripts/lib/llm/model-selector.js
+++ b/scripts/lib/llm/model-selector.js
@@ -1,0 +1,89 @@
+/**
+ * model-selector — 작업/역할에 따른 모델 선택 정책
+ *
+ * 추상화된 라우터 계층. 정책(default/cost-optimized/quality-first/custom)을 교체 가능.
+ * Phase 3에서 비용 메터링 + 폴백 라우팅의 기반이 된다.
+ *
+ * 외부 의존성: complexity-analyzer.getDefaultsForComplexity (modelTiers 정의).
+ */
+
+import { getDefaultsForComplexity } from '../agent/complexity-analyzer.js';
+
+/** 폴백 시 다운그레이드 순서 (가장 강력 → 약함). */
+export const DEFAULT_FALLBACK_CHAIN = ['opus', 'sonnet', 'haiku'];
+
+const STRATEGY_VALIDATORS = new Set(['default', 'cost-optimized', 'quality-first', 'custom']);
+
+/**
+ * 모델 선택기를 생성한다.
+ *
+ * @param {'default'|'cost-optimized'|'quality-first'|'custom'} [strategy='default']
+ * @param {object} [options]
+ * @param {(ctx: { role: object, complexity?: string, taskType?: string }) => string} [options.selectFn]
+ *   - strategy='custom'일 때 사용할 선택 함수
+ * @returns {{
+ *   selectModel: (ctx: { role: object, complexity?: string, taskType?: string }) => string,
+ *   selectFallback: (currentModel: string) => string | null,
+ *   strategy: string,
+ * }}
+ */
+export function createModelSelector(strategy = 'default', options = {}) {
+  const validStrategy = STRATEGY_VALIDATORS.has(strategy) ? strategy : 'default';
+
+  function defaultSelect(ctx) {
+    const { role, complexity, taskType } = ctx;
+    if (!complexity) return role.model;
+
+    const defaults = getDefaultsForComplexity(complexity);
+    const modelTiers = defaults.modelTiers;
+    if (!modelTiers) return role.model;
+
+    const category = role.category || 'engineering';
+    let model = modelTiers[category] || role.model;
+
+    if (taskType === 'architecture-review' && complexity === 'complex') {
+      model = 'opus';
+    }
+    return model;
+  }
+
+  function downgrade(model) {
+    if (model === 'opus') return 'sonnet';
+    if (model === 'sonnet') return 'haiku';
+    return model;
+  }
+
+  function selectModel(ctx) {
+    if (validStrategy === 'custom') {
+      if (typeof options.selectFn === 'function') return options.selectFn(ctx);
+      return defaultSelect(ctx);
+    }
+
+    const baseModel = defaultSelect(ctx);
+
+    if (validStrategy === 'cost-optimized') {
+      // architecture-review는 다운그레이드 금지 (품질 보존)
+      if (ctx.taskType === 'architecture-review') return baseModel;
+      return downgrade(baseModel);
+    }
+
+    if (validStrategy === 'quality-first') {
+      return 'opus';
+    }
+
+    return baseModel;
+  }
+
+  function selectFallback(currentModel) {
+    const idx = DEFAULT_FALLBACK_CHAIN.indexOf(currentModel);
+    if (idx < 0) return null;
+    if (idx === DEFAULT_FALLBACK_CHAIN.length - 1) return null;
+    return DEFAULT_FALLBACK_CHAIN[idx + 1];
+  }
+
+  return {
+    selectModel,
+    selectFallback,
+    strategy: validStrategy,
+  };
+}

--- a/tests/dispatch-plan-generator.test.js
+++ b/tests/dispatch-plan-generator.test.js
@@ -154,6 +154,14 @@ describe('buildDiscussionDispatchPlan', () => {
     // prompt는 { system, user } 객체 — 팀원 정보(정적)는 system에 있음
     expect(plan.reviewPrompts[0].prompt.system).toContain('민준');
   });
+
+  it('명시적 concurrencyHint를 노출한다 (tier 간/내부 모두 병렬)', () => {
+    const plan = buildDiscussionDispatchPlan(SAMPLE_PROJECT, SAMPLE_TEAM);
+    expect(plan.concurrencyHint).toBeDefined();
+    expect(plan.concurrencyHint.allTiersParallel).toBe(true);
+    expect(plan.concurrencyHint.reviewsParallel).toBe(true);
+    expect(plan.concurrencyHint.reasoning).toMatch(/priorTierOutputs/i);
+  });
 });
 
 // --- buildExecutionDispatchPlan ---
@@ -217,6 +225,20 @@ describe('buildExecutionDispatchPlan', () => {
     const plan = buildExecutionDispatchPlan(SAMPLE_PROJECT, SAMPLE_TASKS, SAMPLE_TEAM);
     expect(plan.dependencies).toBeDefined();
     expect(plan.dependencies['task-3']).toContain('task-1');
+  });
+
+  it('execute 페이즈에 concurrencyHint를 노출한다', () => {
+    const plan = buildExecutionDispatchPlan(SAMPLE_PROJECT, SAMPLE_TASKS, SAMPLE_TEAM);
+    const executPhase = plan.phases.find((p) => p.type === 'execute');
+    expect(executPhase.concurrencyHint).toBeDefined();
+    expect(executPhase.concurrencyHint.tasksParallel).toBe(true);
+  });
+
+  it('review 페이즈에 concurrencyHint를 노출한다', () => {
+    const plan = buildExecutionDispatchPlan(SAMPLE_PROJECT, SAMPLE_TASKS, SAMPLE_TEAM);
+    const reviewPhase = plan.phases.find((p) => p.type === 'review');
+    expect(reviewPhase.concurrencyHint).toBeDefined();
+    expect(reviewPhase.concurrencyHint.reviewersParallel).toBe(true);
   });
 
   it('기획 결정사항을 전달할 수 있다', () => {

--- a/tests/llm-pool.test.js
+++ b/tests/llm-pool.test.js
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createLLMPool } from '../scripts/lib/llm/llm-pool.js';
+
+function defer() {
+  let resolveFn;
+  let rejectFn;
+  const promise = new Promise((res, rej) => {
+    resolveFn = res;
+    rejectFn = rej;
+  });
+  return { promise, resolve: resolveFn, reject: rejectFn };
+}
+
+describe('createLLMPool — 글로벌 동시성 제어', () => {
+  it('maxConcurrent 슬롯 수 만큼만 동시에 실행된다', async () => {
+    const pool = createLLMPool({ maxConcurrent: 2 });
+    const inFlight = { count: 0, max: 0 };
+    const deferreds = [defer(), defer(), defer(), defer()];
+
+    const tasks = deferreds.map((d, i) =>
+      pool.run('claude', async () => {
+        inFlight.count++;
+        if (inFlight.count > inFlight.max) inFlight.max = inFlight.count;
+        await d.promise;
+        inFlight.count--;
+        return i;
+      }),
+    );
+
+    // 잠시 기다려 첫 두 개가 in-flight 상태에 들어가게 함
+    await new Promise((r) => setTimeout(r, 10));
+    expect(inFlight.count).toBe(2);
+
+    deferreds[0].resolve();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(inFlight.count).toBe(2);
+
+    deferreds[1].resolve();
+    deferreds[2].resolve();
+    deferreds[3].resolve();
+    const results = await Promise.all(tasks);
+    expect(results).toEqual([0, 1, 2, 3]);
+    expect(inFlight.max).toBe(2);
+  });
+
+  it('태스크가 throw 해도 슬롯이 해제된다', async () => {
+    const pool = createLLMPool({ maxConcurrent: 1 });
+    await expect(
+      pool.run('claude', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    // 다음 작업이 대기 없이 시작되는지 확인
+    const result = await pool.run('claude', async () => 'ok');
+    expect(result).toBe('ok');
+  });
+});
+
+describe('createLLMPool — 프로바이더별 한도', () => {
+  it('프로바이더별 maxConcurrent를 별도로 적용한다', async () => {
+    const pool = createLLMPool({
+      maxConcurrent: 10,
+      perProvider: { claude: 1, openai: 1 },
+    });
+    const counts = { claude: 0, openai: 0 };
+    const max = { claude: 0, openai: 0 };
+    const deferreds = [defer(), defer(), defer(), defer()];
+
+    const tasks = [
+      pool.run('claude', async () => {
+        counts.claude++;
+        max.claude = Math.max(max.claude, counts.claude);
+        await deferreds[0].promise;
+        counts.claude--;
+      }),
+      pool.run('claude', async () => {
+        counts.claude++;
+        max.claude = Math.max(max.claude, counts.claude);
+        await deferreds[1].promise;
+        counts.claude--;
+      }),
+      pool.run('openai', async () => {
+        counts.openai++;
+        max.openai = Math.max(max.openai, counts.openai);
+        await deferreds[2].promise;
+        counts.openai--;
+      }),
+      pool.run('openai', async () => {
+        counts.openai++;
+        max.openai = Math.max(max.openai, counts.openai);
+        await deferreds[3].promise;
+        counts.openai--;
+      }),
+    ];
+
+    await new Promise((r) => setTimeout(r, 10));
+    // claude 1개, openai 1개만 동시 실행
+    expect(counts.claude).toBe(1);
+    expect(counts.openai).toBe(1);
+
+    deferreds.forEach((d) => d.resolve());
+    await Promise.all(tasks);
+
+    expect(max.claude).toBe(1);
+    expect(max.openai).toBe(1);
+  });
+
+  it('글로벌 한도가 프로바이더 한도보다 작으면 글로벌이 우선', async () => {
+    const pool = createLLMPool({
+      maxConcurrent: 1,
+      perProvider: { claude: 5, openai: 5 },
+    });
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const deferreds = [defer(), defer(), defer()];
+
+    const tasks = [
+      pool.run('claude', async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await deferreds[0].promise;
+        inFlight--;
+      }),
+      pool.run('openai', async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await deferreds[1].promise;
+        inFlight--;
+      }),
+      pool.run('gemini', async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await deferreds[2].promise;
+        inFlight--;
+      }),
+    ];
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(inFlight).toBe(1);
+
+    deferreds.forEach((d) => d.resolve());
+    await Promise.all(tasks);
+    expect(maxInFlight).toBe(1);
+  });
+});
+
+describe('createLLMPool — 적응형 backpressure', () => {
+  it('429 신호 시 effective maxConcurrent를 감소시킨다', async () => {
+    const pool = createLLMPool({
+      maxConcurrent: 4,
+      perProvider: { claude: 4 },
+      backpressure: { halveOnRateLimit: true, minConcurrent: 1 },
+    });
+
+    // 처음에는 4 슬롯
+    expect(pool.getEffectiveLimit('claude')).toBe(4);
+
+    pool.signalRateLimit('claude');
+    expect(pool.getEffectiveLimit('claude')).toBe(2);
+
+    pool.signalRateLimit('claude');
+    expect(pool.getEffectiveLimit('claude')).toBe(1);
+
+    pool.signalRateLimit('claude');
+    expect(pool.getEffectiveLimit('claude')).toBe(1); // minConcurrent에서 멈춤
+  });
+
+  it('cooldown 후 effective limit가 회복된다', async () => {
+    vi.useFakeTimers();
+    try {
+      const pool = createLLMPool({
+        maxConcurrent: 4,
+        perProvider: { claude: 4 },
+        backpressure: { halveOnRateLimit: true, minConcurrent: 1, recoveryMs: 1000 },
+      });
+      pool.signalRateLimit('claude');
+      expect(pool.getEffectiveLimit('claude')).toBe(2);
+
+      vi.advanceTimersByTime(1000);
+      expect(pool.getEffectiveLimit('claude')).toBe(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('createLLMPool — drain 다중 깨우기 (backpressure 회복)', () => {
+  it('cooldown 후 effective limit가 회복되면 대기 중인 여러 waiter가 한 번에 깨어난다', async () => {
+    vi.useFakeTimers();
+    try {
+      const pool = createLLMPool({
+        maxConcurrent: 4,
+        perProvider: { claude: 4 },
+        backpressure: { halveOnRateLimit: true, minConcurrent: 1, recoveryMs: 100 },
+      });
+
+      // claude를 1로 줄임 → effective=1
+      pool.signalRateLimit('claude');
+      pool.signalRateLimit('claude');
+      pool.signalRateLimit('claude');
+      expect(pool.getEffectiveLimit('claude')).toBe(1);
+
+      const deferreds = [defer(), defer(), defer(), defer()];
+      let started = 0;
+      const tasks = deferreds.map((d) =>
+        pool.run('claude', async () => {
+          started++;
+          await d.promise;
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(started).toBe(1); // effective=1이라 1개만 실행
+
+      // recoveryMs 경과 → effective 회복 + drain이 여러 waiter 동시 깨움
+      await vi.advanceTimersByTimeAsync(150);
+
+      // 첫 번째 작업이 끝나면 drain이 호출되어 회복된 슬롯 모두 사용
+      deferreds[0].resolve();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // started가 4 (전부 깨어남) — drain의 다중 깨우기 검증
+      expect(started).toBe(4);
+
+      deferreds[1].resolve();
+      deferreds[2].resolve();
+      deferreds[3].resolve();
+      await Promise.all(tasks);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('createLLMPool — 통계', () => {
+  it('getStats() — inFlight, totalRuns, totalErrors', async () => {
+    const pool = createLLMPool({ maxConcurrent: 2 });
+    await pool.run('claude', async () => 'ok');
+    await pool.run('claude', async () => 'ok');
+    await expect(
+      pool.run('claude', async () => {
+        throw new Error('x');
+      }),
+    ).rejects.toThrow();
+
+    const stats = pool.getStats();
+    expect(stats.totalRuns).toBe(3);
+    expect(stats.totalErrors).toBe(1);
+    expect(stats.inFlight).toBe(0);
+    expect(stats.byProvider.claude.runs).toBe(3);
+    expect(stats.byProvider.claude.errors).toBe(1);
+  });
+});

--- a/tests/model-selector.test.js
+++ b/tests/model-selector.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { createModelSelector, DEFAULT_FALLBACK_CHAIN } from '../scripts/lib/llm/model-selector.js';
+
+describe('createModelSelector — default 정책', () => {
+  it('complexity 미지정 시 role.model을 그대로 반환', () => {
+    const selector = createModelSelector('default');
+    const role = { model: 'sonnet', category: 'engineering' };
+    expect(selector.selectModel({ role })).toBe('sonnet');
+  });
+
+  it('complexity 기반으로 카테고리별 modelTiers를 적용', () => {
+    const selector = createModelSelector('default');
+    const role = { model: 'sonnet', category: 'leadership' };
+    expect(selector.selectModel({ role, complexity: 'complex' })).toBe('opus');
+    expect(selector.selectModel({ role, complexity: 'simple' })).toBe('sonnet');
+  });
+
+  it('taskType=architecture-review + complex → opus 업그레이드', () => {
+    const selector = createModelSelector('default');
+    const role = { model: 'sonnet', category: 'engineering' };
+    expect(
+      selector.selectModel({ role, complexity: 'complex', taskType: 'architecture-review' }),
+    ).toBe('opus');
+  });
+
+  it('카테고리 누락 시 engineering으로 폴백', () => {
+    const selector = createModelSelector('default');
+    const role = { model: 'haiku' }; // category 없음
+    expect(selector.selectModel({ role, complexity: 'simple' })).toBe('sonnet');
+  });
+});
+
+describe('createModelSelector — cost-optimized 정책', () => {
+  it('가능한 한 더 저렴한 모델로 다운그레이드', () => {
+    const selector = createModelSelector('cost-optimized');
+    expect(selector.selectModel({ role: { model: 'opus', category: 'leadership' } })).toBe(
+      'sonnet',
+    );
+    expect(selector.selectModel({ role: { model: 'sonnet', category: 'engineering' } })).toBe(
+      'haiku',
+    );
+    expect(selector.selectModel({ role: { model: 'haiku', category: 'support' } })).toBe('haiku');
+  });
+
+  it('architecture-review는 다운그레이드 금지', () => {
+    const selector = createModelSelector('cost-optimized');
+    const role = { model: 'sonnet', category: 'leadership' };
+    expect(
+      selector.selectModel({ role, complexity: 'complex', taskType: 'architecture-review' }),
+    ).toBe('opus');
+  });
+});
+
+describe('createModelSelector — quality-first 정책', () => {
+  it('카테고리에 관계없이 opus로 업그레이드', () => {
+    const selector = createModelSelector('quality-first');
+    expect(selector.selectModel({ role: { model: 'haiku', category: 'support' } })).toBe('opus');
+    expect(selector.selectModel({ role: { model: 'sonnet', category: 'engineering' } })).toBe(
+      'opus',
+    );
+  });
+});
+
+describe('createModelSelector — custom 정책', () => {
+  it('사용자 정의 함수가 적용된다', () => {
+    const customFn = ({ role }) => `custom-${role.category}`;
+    const selector = createModelSelector('custom', { selectFn: customFn });
+    expect(selector.selectModel({ role: { model: 'sonnet', category: 'engineering' } })).toBe(
+      'custom-engineering',
+    );
+  });
+
+  it('selectFn 누락 시 기본 정책으로 폴백', () => {
+    const selector = createModelSelector('custom', {});
+    const role = { model: 'sonnet', category: 'engineering' };
+    expect(selector.selectModel({ role, complexity: 'simple' })).toBe('sonnet');
+  });
+});
+
+describe('ModelSelector — fallback 체인', () => {
+  it('selectFallback: opus → sonnet → haiku 순으로 다운그레이드', () => {
+    const selector = createModelSelector('default');
+    expect(selector.selectFallback('opus')).toBe('sonnet');
+    expect(selector.selectFallback('sonnet')).toBe('haiku');
+    expect(selector.selectFallback('haiku')).toBe(null);
+  });
+
+  it('알 수 없는 모델은 null을 반환', () => {
+    const selector = createModelSelector('default');
+    expect(selector.selectFallback('mystery-7b')).toBe(null);
+  });
+
+  it('DEFAULT_FALLBACK_CHAIN export', () => {
+    expect(DEFAULT_FALLBACK_CHAIN).toEqual(['opus', 'sonnet', 'haiku']);
+  });
+});
+
+describe('ModelSelector — strategy 검증', () => {
+  it('알 수 없는 strategy는 default로 폴백', () => {
+    const selector = createModelSelector('mystery-strategy');
+    const role = { model: 'sonnet', category: 'engineering' };
+    expect(selector.selectModel({ role, complexity: 'simple' })).toBe('sonnet');
+  });
+});


### PR DESCRIPTION
## Summary

오케스트레이션 일반화 Phase 1 — OMC/LangGraph 같은 일반 하네스로 격상하기 위한 기반.

- **LLM 동시성 풀** (`scripts/lib/llm/llm-pool.js`)
  - 글로벌 + 프로바이더별 동시성 제어
  - 429 시 적응형 backpressure (반감 + cooldown 자동 회복)
  - drain은 회복 시 다중 waiter 한 번에 깨움
  - `callLLM` 진입점이 자동 통과 (기존 호출 코드 변경 0)
- **ModelSelector 인터페이스** (`scripts/lib/llm/model-selector.js`)
  - default / cost-optimized / quality-first / custom 정책
  - team-builder.resolveModel은 위임으로 하위호환 유지
  - Phase 3 폴백 라우팅의 기반 (selectFallback 내장)
- **dispatch plan concurrencyHint**
  - 토론/실행 plan에 명시적 병렬 메타 (allTiersParallel, tasksParallel, reviewersParallel)
- **gemini perProvider=1**
  - gemini-bridge가 spawnSync(블로킹)이라 직렬 처리

## Background

oh-my-claudecode/LangGraph와 비교했을 때 GVC의 한계:
- LLM 호출 throttle/queue 부재 → 15명 팀 = 15개 동시 fetch, 429 위험
- 모델 라우팅 로직이 team-builder.js에 박혀 있어 정책 교체 불가

이 PR은 풀과 ModelSelector를 분리해 위 한계를 해소.

## Test plan

- [x] llm-pool 8건, model-selector 13건, dispatch-plan +3건
- [x] 전체 2571 통과, 회귀 0
- [x] npm run lint 통과
- [x] code-reviewer-kr Warning 4건 수정

## 다음 단계 (Phase 2)

- Event-sourced journal 분리
- 파일 레벨 분산 락
- State Machine DSL 도입

🤖 Generated with [Claude Code](https://claude.com/claude-code)