### PR TITLE
feat(lock): 파일 시스템 기반 분산 락 (orchestration Phase 2)

### DIFF
--- a/scripts/lib/core/file-lock.js
+++ b/scripts/lib/core/file-lock.js
@@ -1,0 +1,217 @@
+/**
+ * file-lock — 파일 시스템 기반 분산 락
+ *
+ * 멀티 프로세스 안전. atomic O_EXCL create + PID/timestamp 기록 + stale 감지.
+ * 같은 프로세스 내에서는 reentrant (카운터 기반).
+ *
+ * 외부 의존성 0. proper-lockfile 같은 패키지 대신 자체 구현.
+ */
+
+import { open, unlink, readFile, writeFile, stat, mkdir } from 'fs/promises';
+import { dirname } from 'path';
+
+const DEFAULTS = {
+  timeoutMs: 10_000,
+  retryMs: 50,
+  staleMs: 60_000,
+};
+
+/** 같은 프로세스 내 reentrant 카운터: Map<lockPath, { count: number, owner: symbol }> */
+const reentrantCounts = new Map();
+
+/** 같은 프로세스 내 직렬화 큐: Map<lockPath, Promise<void>> */
+const inProcessQueue = new Map();
+
+function isProcessAlive(pid) {
+  if (typeof pid !== 'number' || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if (err.code === 'ESRCH') return false;
+    if (err.code === 'EPERM') return true;
+    return false;
+  }
+}
+
+async function readLockMeta(lockPath) {
+  try {
+    const raw = await readFile(lockPath, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function isStale(lockPath, staleMs) {
+  const meta = await readLockMeta(lockPath);
+  if (!meta) return false;
+
+  // 같은 PID는 stale 아님 (reentrant는 다른 경로로 처리)
+  if (meta.pid === process.pid) return false;
+
+  // 다른 PID가 죽었으면 stale
+  if (!isProcessAlive(meta.pid)) return true;
+
+  // PID 살아있어도 너무 오래됐으면 stale (hung process)
+  if (typeof meta.acquiredAt !== 'number') return true;
+  if (Date.now() - meta.acquiredAt > staleMs) return true;
+
+  return false;
+}
+
+async function tryWriteLockfile(lockPath) {
+  let handle;
+  try {
+    await mkdir(dirname(lockPath), { recursive: true });
+    handle = await open(lockPath, 'wx');
+    const meta = { pid: process.pid, acquiredAt: Date.now() };
+    await handle.write(JSON.stringify(meta));
+    await handle.close();
+    return true;
+  } catch (err) {
+    if (handle) {
+      try {
+        await handle.close();
+      } catch {
+        // close 실패는 무시
+      }
+    }
+    if (err.code === 'EEXIST') return false;
+    throw err;
+  }
+}
+
+async function forceUnlink(lockPath) {
+  try {
+    await unlink(lockPath);
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
+/**
+ * 파일 락을 획득한다.
+ *
+ * - 같은 프로세스 reentrant: 카운터 증가만
+ * - 다른 프로세스: O_EXCL로 lockfile 시도, 실패 시 stale 검사 후 retry
+ * - timeout 초과 시 에러
+ *
+ * @param {string} lockPath - 락 파일 경로
+ * @param {object} [options]
+ * @param {number} [options.timeoutMs=10000] - 획득 타임아웃
+ * @param {number} [options.retryMs=50] - 재시도 간격
+ * @param {number} [options.staleMs=60000] - stale 판정 임계 (acquiredAt 기준)
+ * @returns {Promise<{ lockPath: string, owner: symbol }>}
+ */
+export async function acquireFileLock(lockPath, options = {}) {
+  const opts = { ...DEFAULTS, ...options };
+
+  // 같은 프로세스 reentrant: 이미 가지고 있으면 카운터만 증가
+  const existing = reentrantCounts.get(lockPath);
+  if (existing) {
+    existing.count++;
+    return { lockPath, owner: existing.owner, reentrant: true };
+  }
+
+  const owner = Symbol('file-lock-owner');
+  const deadline = Date.now() + opts.timeoutMs;
+
+  while (Date.now() <= deadline) {
+    if (await tryWriteLockfile(lockPath)) {
+      reentrantCounts.set(lockPath, { count: 1, owner });
+      return { lockPath, owner, reentrant: false };
+    }
+
+    // 점유된 상태 — stale 검사
+    if (await isStale(lockPath, opts.staleMs)) {
+      await forceUnlink(lockPath);
+      continue; // 즉시 재시도
+    }
+
+    await new Promise((r) => setTimeout(r, opts.retryMs));
+  }
+
+  const meta = await readLockMeta(lockPath);
+  const holder = meta
+    ? `pid=${meta.pid}, acquiredAt=${new Date(meta.acquiredAt).toISOString()}`
+    : 'unknown';
+  throw new Error(`file lock 획득 실패: ${lockPath} (${holder}, timeout=${opts.timeoutMs}ms)`);
+}
+
+/**
+ * 파일 락을 해제한다.
+ * @param {{ lockPath: string, owner: symbol, reentrant?: boolean }} handle
+ */
+export async function releaseFileLock(handle) {
+  if (!handle || !handle.lockPath) return;
+  const { lockPath, owner } = handle;
+
+  const entry = reentrantCounts.get(lockPath);
+  if (!entry || entry.owner !== owner) return;
+
+  entry.count--;
+  if (entry.count > 0) return;
+
+  reentrantCounts.delete(lockPath);
+  await forceUnlink(lockPath);
+}
+
+/**
+ * 락 안에서 fn을 실행한다. 동일 프로세스 동시 호출은 직렬화된다.
+ * @template T
+ * @param {string} lockPath
+ * @param {() => Promise<T>} fn
+ * @param {object} [options]
+ * @returns {Promise<T>}
+ */
+export async function withFileLock(lockPath, fn, options = {}) {
+  // In-process 직렬화: 같은 lockPath의 동시 호출이 reentrant로 들어가지 않게
+  const prev = inProcessQueue.get(lockPath) || Promise.resolve();
+  let releaseQueue;
+  const queuePromise = new Promise((r) => {
+    releaseQueue = r;
+  });
+  inProcessQueue.set(lockPath, queuePromise);
+
+  await prev;
+  try {
+    const handle = await acquireFileLock(lockPath, options);
+    try {
+      return await fn();
+    } finally {
+      await releaseFileLock(handle);
+    }
+  } finally {
+    releaseQueue();
+    if (inProcessQueue.get(lockPath) === queuePromise) {
+      inProcessQueue.delete(lockPath);
+    }
+  }
+}
+
+/**
+ * 락 디렉토리가 존재하는지 확인한다 (테스트/디버깅용).
+ * @param {string} lockPath
+ * @returns {Promise<object|null>} lockfile meta 또는 null
+ */
+export async function inspectLock(lockPath) {
+  try {
+    await stat(lockPath);
+    return await readLockMeta(lockPath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 테스트용 — reentrant 상태를 초기화한다.
+ */
+export function _resetForTesting() {
+  reentrantCounts.clear();
+  inProcessQueue.clear();
+}
+
+// writeFile은 fs/promises에서 import했지만 내부에서 사용하지 않음.
+// future: lockfile에 추가 메타 기록 시 사용.
+void writeFile;

--- a/scripts/lib/project/project-manager.js
+++ b/scripts/lib/project/project-manager.js
@@ -11,6 +11,7 @@ import {
 import { projectsDir } from '../core/app-paths.js';
 import { config } from '../core/config.js';
 import { truncateLines } from '../core/text-utils.js';
+import { withFileLock } from '../core/file-lock.js';
 
 const DEFAULT_BASE_DIR = projectsDir();
 
@@ -86,12 +87,6 @@ function getProjectFilePath(projectId) {
 }
 
 /**
- * In-process 쓰기 락 — 동일 프로젝트에 대한 동시 쓰기를 직렬화한다.
- * @type {Map<string, Promise<void>>}
- */
-const writeLocks = new Map();
-
-/**
  * 프로젝트 파일을 디스크에서 읽는다.
  * @param {string} projectId - 프로젝트 ID
  * @returns {Promise<object|null>} 프로젝트 또는 null (파일 없음)
@@ -112,33 +107,37 @@ async function writeProjectFile(projectId, project) {
 }
 
 /**
+ * 프로젝트 락 파일 경로.
+ *
+ * 프로젝트 디렉토리 밖(`baseDir/.locks/`)에 두어 호출자가 ensureDir을 거치지 않게 한다.
+ * 호출 시점에 비동기 ensureDir이 끼면 dispatch 순서와 큐 등록 순서가 어긋날 수 있다.
+ */
+function getProjectLockPath(projectId) {
+  // projectId 검증을 통과한 디렉토리만 락 경로로 허용
+  const projectDir = getProjectDir(projectId);
+  void projectDir; // assertWithinRoot 부수효과
+  return resolve(baseDir, '.locks', `${projectId}.lock`);
+}
+
+/**
  * 프로젝트 락을 획득하고 read → mutate → write 사이클을 원자적으로 수행한다.
+ *
+ * 파일 시스템 기반 잠금이라 멀티 프로세스에서도 안전하다.
+ * 같은 프로세스 내에서는 reentrant + 직렬화 (dispatch 순서 보존).
+ *
  * @param {string} projectId - 프로젝트 ID
  * @param {function} fn - (project) => updatedProject 변환 함수
  * @returns {Promise<object>} 업데이트된 프로젝트
  */
 async function withProjectLock(projectId, fn) {
-  const prev = writeLocks.get(projectId) || Promise.resolve();
-  let resolveLock;
-  const lockPromise = new Promise((r) => {
-    resolveLock = r;
-  });
-  writeLocks.set(projectId, lockPromise);
-
-  await prev;
-  try {
+  const lockPath = getProjectLockPath(projectId);
+  return withFileLock(lockPath, async () => {
     const project = await readProjectFile(projectId);
     if (!project) throw notFoundError(`프로젝트를 찾을 수 없습니다: ${projectId}`);
     const updated = fn(project);
     await writeProjectFile(projectId, updated);
     return updated;
-  } finally {
-    resolveLock();
-    // 현재 락이 Map에 남아있으면 삭제 (누수 방지)
-    if (writeLocks.get(projectId) === lockPromise) {
-      writeLocks.delete(projectId);
-    }
-  }
+  });
 }
 
 /**

--- a/tests/file-lock.test.js
+++ b/tests/file-lock.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { acquireFileLock, releaseFileLock, withFileLock } from '../scripts/lib/core/file-lock.js';
+
+let tmpDir;
+let lockPath;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'gvc-lock-'));
+  lockPath = join(tmpDir, '.lock');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('acquireFileLock / releaseFileLock', () => {
+  it('획득 후 lockfile이 존재하고, 해제 후 사라진다', async () => {
+    const handle = await acquireFileLock(lockPath);
+    expect(existsSync(lockPath)).toBe(true);
+    await releaseFileLock(handle);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('lockfile에는 PID와 timestamp가 JSON으로 기록된다', async () => {
+    const handle = await acquireFileLock(lockPath);
+    const { readFileSync } = await import('fs');
+    const content = JSON.parse(readFileSync(lockPath, 'utf-8'));
+    expect(content.pid).toBe(process.pid);
+    expect(typeof content.acquiredAt).toBe('number');
+    await releaseFileLock(handle);
+  });
+
+  it('같은 프로세스에서 재진입(reentrant)이 가능하다 — 카운트 기반', async () => {
+    const handle1 = await acquireFileLock(lockPath);
+    const handle2 = await acquireFileLock(lockPath);
+    expect(existsSync(lockPath)).toBe(true);
+
+    await releaseFileLock(handle2);
+    expect(existsSync(lockPath)).toBe(true); // 첫 락은 살아있음
+
+    await releaseFileLock(handle1);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('이미 점유된 락은 retry 후 timeout 시 에러를 던진다', async () => {
+    // 살아있는 다른 프로세스 흉내 (ppid는 거의 항상 alive — vitest 부모)
+    writeFileSync(lockPath, JSON.stringify({ pid: process.ppid, acquiredAt: Date.now() }));
+
+    await expect(
+      acquireFileLock(lockPath, { timeoutMs: 200, retryMs: 50, staleMs: 60_000 }),
+    ).rejects.toThrow(/lock/i);
+  });
+
+  it('stale lock (죽은 PID 또는 staleMs 초과)은 강제 해제된다', async () => {
+    // staleMs를 매우 짧게 + 매우 오래된 timestamp
+    writeFileSync(lockPath, JSON.stringify({ pid: 999999, acquiredAt: Date.now() - 1_000_000 }));
+
+    const handle = await acquireFileLock(lockPath, {
+      timeoutMs: 1000,
+      retryMs: 50,
+      staleMs: 500,
+    });
+
+    const { readFileSync } = await import('fs');
+    const content = JSON.parse(readFileSync(lockPath, 'utf-8'));
+    expect(content.pid).toBe(process.pid);
+    await releaseFileLock(handle);
+  });
+});
+
+describe('withFileLock', () => {
+  it('fn이 락 안에서 실행되고, 정상 종료 시 락이 해제된다', async () => {
+    const result = await withFileLock(lockPath, async () => {
+      expect(existsSync(lockPath)).toBe(true);
+      return 'ok';
+    });
+    expect(result).toBe('ok');
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('fn이 throw 해도 락이 해제된다', async () => {
+    await expect(
+      withFileLock(lockPath, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('동일 프로세스 동시 호출 시 직렬화된다', async () => {
+    const order = [];
+    const t1 = withFileLock(lockPath, async () => {
+      order.push('t1-start');
+      await new Promise((r) => setTimeout(r, 50));
+      order.push('t1-end');
+    });
+    const t2 = withFileLock(lockPath, async () => {
+      order.push('t2-start');
+      order.push('t2-end');
+    });
+    await Promise.all([t1, t2]);
+    expect(order).toEqual(['t1-start', 't1-end', 't2-start', 't2-end']);
+  });
+});


### PR DESCRIPTION
## Summary

오케스트레이션 일반화 Phase 2 — 인메모리 writeLocks를 파일 시스템 잠금으로 격상.

- **file-lock 모듈** (`scripts/lib/core/file-lock.js`)
  - O_EXCL atomic create + PID/timestamp 기록 + stale 감지
  - 같은 프로세스 reentrant (카운터 기반)
  - 같은 프로세스 직렬화 큐 (dispatch 순서 보존)
  - 다른 PID 죽음 또는 staleMs 초과 시 강제 해제
  - timeout 초과 시 hold owner 정보 포함 에러
  - 외부 의존성 0 (proper-lockfile 미사용)

- **project-manager.withProjectLock**
  - in-memory Map → withFileLock 위임
  - lockfile은 `baseDir/.locks/<id>.lock` — 프로젝트 디렉토리 밖에 두어 호출자가 ensureDir 거치지 않게 함 (race 방지)
  - file-lock의 tryWriteLockfile이 parent dir 자동 생성

## Background

LangGraph/Temporal 같은 산업 표준 워크플로우 엔진은 멀티 프로세스/머신 동시성을 전제로 한다.
GVC는 인메모리 Map으로 같은 프로세스 내에서만 동시 쓰기를 직렬화했다 — 분산 실행 시 충돌 위험.
이 PR로 같은 lockfile을 보는 모든 프로세스가 안전하게 협력 가능.

## Test plan

- [x] `tests/file-lock.test.js` 8건 (acquire/release, reentrant, stale, timeout, withFileLock 직렬화)
- [x] 전체 2579 통과 (+8), 회귀 0
- [x] `npm run lint` 통과
- [x] project-manager 80개 기존 테스트 통과 (concurrency 스트레스 10개 직렬화 검증 포함)

## 다음 단계

- Event-sourced journal 분리 (project.json 비대 해결)
- State Machine DSL 도입 (state-machine.js 암묵 분기 명시화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)