### PR TITLE
feat(journal): append-only 이벤트 로그 모듈 (orchestration Phase 2)

### DIFF
--- a/scripts/lib/project/journal.js
+++ b/scripts/lib/project/journal.js
@@ -185,3 +185,11 @@ export async function clearJournal(projectId) {
 export function getJournalFilePath(projectId) {
   return getJournalPath(projectId);
 }
+
+/**
+ * 테스트용 — monotonic timestamp 카운터를 초기화한다.
+ * 다른 테스트에서 누적된 lastAutoTimestamp가 Date.now() 비교를 깨지 않게 한다.
+ */
+export function _resetTimestampForTesting() {
+  lastAutoTimestamp = 0;
+}

--- a/scripts/lib/project/journal.js
+++ b/scripts/lib/project/journal.js
@@ -1,0 +1,173 @@
+/**
+ * journal — append-only 이벤트 로그 (JSONL)
+ *
+ * project.json에 journal[]을 끼우면 매번 read/write에서 전체를 serialize 해야 한다.
+ * 별도 jsonl 파일로 분리하여 append는 O(1), 읽기는 stream 기반으로 가능하게 한다.
+ *
+ * Phase 2 일반화의 핵심 — 수십~수백 phase의 대규모 프로젝트에서 I/O 폭증 방지.
+ *
+ * 외부 의존성 0. file-lock으로 직렬화.
+ */
+
+import { appendFile, readFile, unlink, writeFile, mkdir } from 'fs/promises';
+import { resolve, dirname } from 'path';
+import { projectsDir } from '../core/app-paths.js';
+import { withFileLock } from '../core/file-lock.js';
+import { inputError } from '../core/validators.js';
+
+let baseDir = projectsDir();
+
+/**
+ * 테스트용 — journal 파일들의 베이스 디렉토리 설정.
+ * @param {string} dir
+ */
+export function setJournalBaseDir(dir) {
+  baseDir = dir;
+}
+
+function getJournalPath(projectId) {
+  return resolve(baseDir, projectId, 'journal.jsonl');
+}
+
+function getJournalLockPath(projectId) {
+  return resolve(baseDir, '.locks', `${projectId}-journal.lock`);
+}
+
+function normalizeEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    throw inputError('journal entry는 object여야 합니다');
+  }
+  if (!entry.type || typeof entry.type !== 'string') {
+    throw inputError('journal entry는 type 필드가 필요합니다');
+  }
+  return {
+    timestamp: typeof entry.timestamp === 'number' ? entry.timestamp : Date.now(),
+    ...entry,
+  };
+}
+
+function parseLines(content) {
+  if (!content) return [];
+  const lines = content.split('\n');
+  const out = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed === 'object') out.push(parsed);
+    } catch {
+      // 손상된 줄 skip
+    }
+  }
+  return out;
+}
+
+async function readRawEntries(projectId) {
+  try {
+    const content = await readFile(getJournalPath(projectId), 'utf-8');
+    return parseLines(content);
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+/**
+ * journal에 entry를 추가한다 (append-only).
+ *
+ * @param {string} projectId
+ * @param {{ type: string, timestamp?: number, [key: string]: any }} entry
+ * @returns {Promise<object>} 정규화된 entry (timestamp 포함)
+ */
+export async function appendJournalEntry(projectId, entry) {
+  const normalized = normalizeEntry(entry);
+  const lockPath = getJournalLockPath(projectId);
+
+  return withFileLock(lockPath, async () => {
+    const journalPath = getJournalPath(projectId);
+    await mkdir(dirname(journalPath), { recursive: true });
+    await appendFile(journalPath, JSON.stringify(normalized) + '\n', 'utf-8');
+    return normalized;
+  });
+}
+
+/**
+ * journal entry를 읽는다.
+ *
+ * @param {string} projectId
+ * @param {object} [options]
+ * @param {string} [options.type] - 특정 type 필터
+ * @param {number} [options.since] - 이 timestamp 초과 entry만
+ * @param {number} [options.limit] - 최근 N개만 (필터 적용 후)
+ * @returns {Promise<Array<object>>}
+ */
+export async function readJournalEntries(projectId, options = {}) {
+  const all = await readRawEntries(projectId);
+  let filtered = all;
+
+  if (options.type) {
+    filtered = filtered.filter((e) => e.type === options.type);
+  }
+
+  if (typeof options.since === 'number') {
+    filtered = filtered.filter(
+      (e) => typeof e.timestamp === 'number' && e.timestamp > options.since,
+    );
+  }
+
+  if (typeof options.limit === 'number' && options.limit >= 0) {
+    filtered = filtered.slice(-options.limit);
+  }
+
+  return filtered;
+}
+
+/**
+ * journal을 마지막 N entry만 남기고 잘라낸다 (오래된 것 제거).
+ *
+ * @param {string} projectId
+ * @param {number} maxLines
+ */
+export async function truncateJournalAtSize(projectId, maxLines) {
+  if (typeof maxLines !== 'number' || maxLines < 0) {
+    throw inputError('maxLines는 0 이상의 숫자여야 합니다');
+  }
+  const lockPath = getJournalLockPath(projectId);
+
+  return withFileLock(lockPath, async () => {
+    const all = await readRawEntries(projectId);
+    if (all.length <= maxLines) return;
+
+    const journalPath = getJournalPath(projectId);
+    const kept = all.slice(-maxLines);
+    const content = kept.map((e) => JSON.stringify(e)).join('\n') + (kept.length > 0 ? '\n' : '');
+    await writeFile(journalPath, content, 'utf-8');
+  });
+}
+
+/**
+ * journal 파일을 완전히 제거한다.
+ *
+ * @param {string} projectId
+ */
+export async function clearJournal(projectId) {
+  const lockPath = getJournalLockPath(projectId);
+
+  return withFileLock(lockPath, async () => {
+    try {
+      await unlink(getJournalPath(projectId));
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+    }
+  });
+}
+
+/**
+ * journal 파일 경로를 반환한다 (테스트/디버깅용).
+ * @param {string} projectId
+ * @returns {string}
+ */
+export function getJournalFilePath(projectId) {
+  return getJournalPath(projectId);
+}

--- a/scripts/lib/project/journal.js
+++ b/scripts/lib/project/journal.js
@@ -33,6 +33,13 @@ function getJournalLockPath(projectId) {
   return resolve(baseDir, '.locks', `${projectId}-journal.lock`);
 }
 
+/**
+ * 자동 할당 timestamp의 monotonic 보장용. 같은 ms 내 다중 append 시에도
+ * 순서가 보존되도록 (now <= last)일 때 last+1로 증가시킨다.
+ * 명시 timestamp가 들어오면 그대로 사용한다 (재현/마이그레이션 케이스).
+ */
+let lastAutoTimestamp = 0;
+
 function normalizeEntry(entry) {
   if (!entry || typeof entry !== 'object') {
     throw inputError('journal entry는 object여야 합니다');
@@ -40,10 +47,17 @@ function normalizeEntry(entry) {
   if (!entry.type || typeof entry.type !== 'string') {
     throw inputError('journal entry는 type 필드가 필요합니다');
   }
-  return {
-    timestamp: typeof entry.timestamp === 'number' ? entry.timestamp : Date.now(),
-    ...entry,
-  };
+
+  let timestamp;
+  if (typeof entry.timestamp === 'number') {
+    timestamp = entry.timestamp;
+  } else {
+    const now = Date.now();
+    timestamp = now <= lastAutoTimestamp ? lastAutoTimestamp + 1 : now;
+    lastAutoTimestamp = timestamp;
+  }
+
+  return { timestamp, ...entry };
 }
 
 function parseLines(content) {

--- a/tests/journal.test.js
+++ b/tests/journal.test.js
@@ -8,6 +8,7 @@ import {
   truncateJournalAtSize,
   clearJournal,
   setJournalBaseDir,
+  _resetTimestampForTesting,
 } from '../scripts/lib/project/journal.js';
 
 let tmpDir;
@@ -16,6 +17,7 @@ const projectId = 'test-project-2026-04';
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'gvc-journal-'));
   setJournalBaseDir(tmpDir);
+  _resetTimestampForTesting();
 });
 
 afterEach(() => {

--- a/tests/journal.test.js
+++ b/tests/journal.test.js
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  appendJournalEntry,
+  readJournalEntries,
+  truncateJournalAtSize,
+  clearJournal,
+  setJournalBaseDir,
+} from '../scripts/lib/project/journal.js';
+
+let tmpDir;
+const projectId = 'test-project-2026-04';
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'gvc-journal-'));
+  setJournalBaseDir(tmpDir);
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('appendJournalEntry / readJournalEntries', () => {
+  it('빈 journal에 entry를 추가하고 읽을 수 있다', async () => {
+    await appendJournalEntry(projectId, { type: 'phase-start', phase: 1 });
+    const entries = await readJournalEntries(projectId);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].type).toBe('phase-start');
+    expect(entries[0].phase).toBe(1);
+    expect(typeof entries[0].timestamp).toBe('number');
+  });
+
+  it('파일이 없으면 빈 배열을 반환한다', async () => {
+    const entries = await readJournalEntries(projectId);
+    expect(entries).toEqual([]);
+  });
+
+  it('여러 entry를 순서대로 보존한다', async () => {
+    await appendJournalEntry(projectId, { type: 'a' });
+    await appendJournalEntry(projectId, { type: 'b' });
+    await appendJournalEntry(projectId, { type: 'c' });
+    const entries = await readJournalEntries(projectId);
+    expect(entries.map((e) => e.type)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('동시 append가 직렬화되어 모든 entry가 보존된다', async () => {
+    const tasks = Array.from({ length: 20 }, (_, i) =>
+      appendJournalEntry(projectId, { type: 'event', seq: i }),
+    );
+    await Promise.all(tasks);
+    const entries = await readJournalEntries(projectId);
+    expect(entries).toHaveLength(20);
+    const seqs = entries.map((e) => e.seq).sort((a, b) => a - b);
+    expect(seqs).toEqual([...Array(20).keys()]);
+  });
+
+  it('손상된 줄(invalid JSON)은 건너뛴다', async () => {
+    await appendJournalEntry(projectId, { type: 'good-1' });
+    const journalPath = join(tmpDir, projectId, 'journal.jsonl');
+    const fs = await import('fs/promises');
+    await fs.appendFile(journalPath, 'INVALID JSON LINE\n');
+    await appendJournalEntry(projectId, { type: 'good-2' });
+
+    const entries = await readJournalEntries(projectId);
+    expect(entries.map((e) => e.type)).toEqual(['good-1', 'good-2']);
+  });
+
+  it('빈 줄은 건너뛴다', async () => {
+    await appendJournalEntry(projectId, { type: 'a' });
+    const journalPath = join(tmpDir, projectId, 'journal.jsonl');
+    const fs = await import('fs/promises');
+    await fs.appendFile(journalPath, '\n\n');
+    await appendJournalEntry(projectId, { type: 'b' });
+
+    const entries = await readJournalEntries(projectId);
+    expect(entries.map((e) => e.type)).toEqual(['a', 'b']);
+  });
+});
+
+describe('readJournalEntries 옵션', () => {
+  beforeEach(async () => {
+    await appendJournalEntry(projectId, { type: 'a', seq: 0 });
+    await appendJournalEntry(projectId, { type: 'b', seq: 1 });
+    await appendJournalEntry(projectId, { type: 'a', seq: 2 });
+    await appendJournalEntry(projectId, { type: 'c', seq: 3 });
+  });
+
+  it('limit 옵션은 가장 최근 N개만 반환한다', async () => {
+    const entries = await readJournalEntries(projectId, { limit: 2 });
+    expect(entries.map((e) => e.seq)).toEqual([2, 3]);
+  });
+
+  it('type 필터로 특정 type entry만 반환한다', async () => {
+    const entries = await readJournalEntries(projectId, { type: 'a' });
+    expect(entries.map((e) => e.seq)).toEqual([0, 2]);
+  });
+
+  it('since (timestamp) 필터로 그 이후 entry만 반환한다', async () => {
+    const all = await readJournalEntries(projectId);
+    const sinceTs = all[1].timestamp;
+    const entries = await readJournalEntries(projectId, { since: sinceTs });
+    expect(entries.map((e) => e.seq)).toEqual([2, 3]);
+  });
+});
+
+describe('truncateJournalAtSize', () => {
+  it('maxLines를 초과한 오래된 entry를 제거한다', async () => {
+    for (let i = 0; i < 10; i++) {
+      await appendJournalEntry(projectId, { type: 'event', seq: i });
+    }
+    await truncateJournalAtSize(projectId, 3);
+
+    const entries = await readJournalEntries(projectId);
+    expect(entries).toHaveLength(3);
+    expect(entries.map((e) => e.seq)).toEqual([7, 8, 9]);
+  });
+
+  it('maxLines 미만이면 변경 없음', async () => {
+    await appendJournalEntry(projectId, { type: 'a' });
+    await appendJournalEntry(projectId, { type: 'b' });
+    await truncateJournalAtSize(projectId, 10);
+
+    const entries = await readJournalEntries(projectId);
+    expect(entries).toHaveLength(2);
+  });
+
+  it('파일이 없어도 에러 없음', async () => {
+    await expect(truncateJournalAtSize('nonexistent', 5)).resolves.not.toThrow();
+  });
+});
+
+describe('clearJournal', () => {
+  it('journal 파일을 삭제한다', async () => {
+    await appendJournalEntry(projectId, { type: 'a' });
+    const journalPath = join(tmpDir, projectId, 'journal.jsonl');
+    expect(existsSync(journalPath)).toBe(true);
+
+    await clearJournal(projectId);
+    expect(existsSync(journalPath)).toBe(false);
+  });
+
+  it('파일이 없어도 에러 없음', async () => {
+    await expect(clearJournal('nonexistent')).resolves.not.toThrow();
+  });
+});
+
+describe('appendJournalEntry — entry 정규화', () => {
+  it('timestamp가 자동 추가된다', async () => {
+    const before = Date.now();
+    await appendJournalEntry(projectId, { type: 'x' });
+    const after = Date.now();
+    const entries = await readJournalEntries(projectId);
+    expect(entries[0].timestamp).toBeGreaterThanOrEqual(before);
+    expect(entries[0].timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it('명시적 timestamp가 있으면 그대로 사용한다', async () => {
+    await appendJournalEntry(projectId, { type: 'x', timestamp: 12345 });
+    const entries = await readJournalEntries(projectId);
+    expect(entries[0].timestamp).toBe(12345);
+  });
+
+  it('type 필드는 필수다', async () => {
+    // 어차피 외부 입력이라 검증
+    writeFileSync;
+    await expect(appendJournalEntry(projectId, {})).rejects.toThrow(/type/i);
+  });
+});

--- a/tests/journal.test.js
+++ b/tests/journal.test.js
@@ -101,6 +101,7 @@ describe('readJournalEntries 옵션', () => {
     const all = await readJournalEntries(projectId);
     const sinceTs = all[1].timestamp;
     const entries = await readJournalEntries(projectId, { since: sinceTs });
+    // monotonic timestamp 보장 — seq=2,3은 ts(1) 보다 항상 크다
     expect(entries.map((e) => e.seq)).toEqual([2, 3]);
   });
 });


### PR DESCRIPTION
## Summary

오케스트레이션 일반화 Phase 2 — project.json 비대 문제 해결의 첫 단계.

기존 `executionState.journal[]`은 매번 read/write에 전체 array를 serialize한다.
수십~수백 phase의 대규모 프로젝트에서 I/O가 폭증한다.

이 PR은 **새 모듈만 추가**한다. 기존 코드 마이그레이션은 후속 PR.

## Module: scripts/lib/project/journal.js

- `appendJournalEntry`: O(1) append (jsonl)
- `readJournalEntries`: type/since/limit 필터 지원
- `truncateJournalAtSize`: 오래된 entry 제거
- `clearJournal`: 전체 제거
- 손상된 줄 (invalid JSON, 빈 줄) 자동 skip
- file-lock으로 직렬화 (멀티 프로세스 안전)
- 외부 의존성 0

## Background

LangGraph/Temporal 같은 산업 표준은 event-sourced 패턴이 기본:
- 상태 변경은 immutable event log에 append
- 현재 상태는 snapshot + replay로 도출
- 감사성/디버깅성 우수, append O(1)

GVC는 단일 JSON 문서 모델로 시작했으나, 오케스트레이션 툴로 일반화하려면
event log가 필요. 점진적으로 옮긴다.

## Test plan

- [x] `tests/journal.test.js` 17건 (append/read 사이클, 동시성 20건 직렬화, 필터, truncate, 손상 복구)
- [x] 전체 2596 통과 (+17), 회귀 0
- [x] `npm run lint` 통과

## 다음 단계

- 기존 `executionState.journal[]` 사용처를 점진적으로 jsonl로 마이그레이션
- State Machine DSL 도입

🤖 Generated with [Claude Code](https://claude.com/claude-code)