### PR TITLE
feat(state): 경량 상태 머신 DSL (orchestration Phase 2)

### DIFF
--- a/scripts/lib/core/state-machine-dsl.js
+++ b/scripts/lib/core/state-machine-dsl.js
@@ -1,0 +1,184 @@
+/**
+ * state-machine-dsl — 경량 상태 머신 정의 DSL
+ *
+ * xstate 같은 라이브러리 없이 자체 구현. 명시적 transition 표현으로
+ * state-machine.js의 암묵적 if-else 분기를 대체할 기반.
+ *
+ * 정의 형식:
+ * ```js
+ * const machine = defineStateMachine({
+ *   initial: 'planning',
+ *   states: {
+ *     planning: {
+ *       on: {
+ *         APPROVE: { target: 'approved', guard: (ctx) => ..., actions: (ctx) => [...] },
+ *         RESET: { target: 'planning' },
+ *       },
+ *     },
+ *     ...
+ *   },
+ * });
+ * ```
+ *
+ * 외부 의존성 0.
+ */
+
+import { inputError } from './validators.js';
+
+function validateDefinition(def) {
+  if (!def || typeof def !== 'object') throw inputError('state machine 정의는 object여야 합니다');
+  if (!def.states || typeof def.states !== 'object') {
+    throw inputError('state machine은 states 객체가 필요합니다');
+  }
+  const stateNames = Object.keys(def.states);
+  if (stateNames.length === 0) {
+    throw inputError('state machine은 최소 1개의 state가 필요합니다');
+  }
+  if (!def.initial || !stateNames.includes(def.initial)) {
+    throw inputError(`initial state "${def.initial}"가 states에 정의되지 않았습니다`);
+  }
+
+  for (const [stateName, stateDef] of Object.entries(def.states)) {
+    if (!stateDef || typeof stateDef !== 'object') {
+      throw inputError(`state "${stateName}" 정의가 올바르지 않습니다`);
+    }
+    const transitions = stateDef.on || {};
+    for (const [eventName, transition] of Object.entries(transitions)) {
+      if (!transition || typeof transition !== 'object' || !transition.target) {
+        throw inputError(`transition "${stateName}.on.${eventName}"에 target이 없습니다`);
+      }
+      if (!stateNames.includes(transition.target)) {
+        throw inputError(
+          `transition "${stateName}.on.${eventName}"의 target "${transition.target}"이 정의되지 않은 state입니다`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * 상태 머신을 정의한다.
+ *
+ * @param {object} definition
+ * @param {string} definition.initial - 초기 state
+ * @param {Object<string, { on?: Object<string, { target: string, guard?: Function, actions?: Function }> }>} definition.states
+ * @returns {{
+ *   initial: string,
+ *   transition: (state: string, event: string, options?: { context?: any }) => { valid: boolean, state: string, error?: string, actions: any[] },
+ *   canTransition: (state: string, event: string) => boolean,
+ *   availableEvents: (state: string) => string[],
+ *   reachableStates: (state: string) => string[],
+ *   allStates: () => string[],
+ * }}
+ */
+export function defineStateMachine(definition) {
+  validateDefinition(definition);
+
+  const { initial, states } = definition;
+  const stateNames = Object.keys(states);
+
+  function getTransition(state, event) {
+    const stateDef = states[state];
+    if (!stateDef) return null;
+    return (stateDef.on || {})[event] || null;
+  }
+
+  function transition(state, event, options = {}) {
+    if (!stateNames.includes(state)) {
+      return {
+        valid: false,
+        state,
+        error: `알 수 없는 state: ${state}`,
+        actions: [],
+      };
+    }
+
+    const trans = getTransition(state, event);
+    if (!trans) {
+      return {
+        valid: false,
+        state,
+        error: `state "${state}"에서 event "${event}" 처리 불가`,
+        actions: [],
+      };
+    }
+
+    const ctx = options.context;
+
+    if (typeof trans.guard === 'function') {
+      let allowed;
+      try {
+        allowed = Boolean(trans.guard(ctx));
+      } catch (err) {
+        return {
+          valid: false,
+          state,
+          error: `guard 실행 중 오류: ${err.message}`,
+          actions: [],
+        };
+      }
+      if (!allowed) {
+        return {
+          valid: false,
+          state,
+          error: `guard 거부: ${state}.on.${event}`,
+          actions: [],
+        };
+      }
+    }
+
+    let actions = [];
+    if (typeof trans.actions === 'function') {
+      try {
+        const result = trans.actions(ctx);
+        actions = Array.isArray(result) ? result : [];
+      } catch (err) {
+        return {
+          valid: false,
+          state,
+          error: `actions 실행 중 오류: ${err.message}`,
+          actions: [],
+        };
+      }
+    }
+
+    return {
+      valid: true,
+      state: trans.target,
+      actions,
+    };
+  }
+
+  function canTransition(state, event) {
+    return getTransition(state, event) !== null;
+  }
+
+  function availableEvents(state) {
+    const stateDef = states[state];
+    if (!stateDef) return [];
+    return Object.keys(stateDef.on || {});
+  }
+
+  function reachableStates(state) {
+    const stateDef = states[state];
+    if (!stateDef) return [];
+    const targets = new Set();
+    for (const trans of Object.values(stateDef.on || {})) {
+      targets.add(trans.target);
+    }
+    return [...targets];
+  }
+
+  function allStates() {
+    return [...stateNames];
+  }
+
+  return {
+    initial,
+    transition,
+    canTransition,
+    availableEvents,
+    reachableStates,
+    allStates,
+  };
+}

--- a/tests/state-machine-dsl.test.js
+++ b/tests/state-machine-dsl.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { defineStateMachine } from '../scripts/lib/core/state-machine-dsl.js';
+
+const projectMachine = defineStateMachine({
+  initial: 'planning',
+  states: {
+    planning: {
+      on: {
+        APPROVE: { target: 'approved' },
+        RESET: { target: 'planning' },
+      },
+    },
+    approved: {
+      on: {
+        EXECUTE: {
+          target: 'executing',
+          guard: (ctx) => ctx.team && ctx.team.length > 0,
+        },
+        REJECT: { target: 'planning' },
+      },
+    },
+    executing: {
+      on: {
+        REVIEW: { target: 'reviewing' },
+        COMPLETE: { target: 'completed' },
+      },
+    },
+    reviewing: {
+      on: {
+        FIX: { target: 'executing' },
+        COMPLETE: { target: 'completed' },
+      },
+    },
+    completed: {
+      on: {
+        MODIFY: { target: 'approved' },
+      },
+    },
+  },
+});
+
+describe('defineStateMachine — 기본 transition', () => {
+  it('initial 상태를 노출한다', () => {
+    expect(projectMachine.initial).toBe('planning');
+  });
+
+  it('정의된 event는 target state로 전이된다', () => {
+    const result = projectMachine.transition('planning', 'APPROVE');
+    expect(result.valid).toBe(true);
+    expect(result.state).toBe('approved');
+  });
+
+  it('알 수 없는 event는 invalid를 반환한다', () => {
+    const result = projectMachine.transition('planning', 'UNKNOWN_EVENT');
+    expect(result.valid).toBe(false);
+    expect(result.state).toBe('planning');
+    expect(result.error).toMatch(/event/i);
+  });
+
+  it('알 수 없는 state는 invalid를 반환한다', () => {
+    const result = projectMachine.transition('mystery-state', 'APPROVE');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/state/i);
+  });
+
+  it('self-transition도 허용된다', () => {
+    const result = projectMachine.transition('planning', 'RESET');
+    expect(result.valid).toBe(true);
+    expect(result.state).toBe('planning');
+  });
+});
+
+describe('defineStateMachine — guard', () => {
+  it('guard가 true를 반환하면 transition 통과', () => {
+    const result = projectMachine.transition('approved', 'EXECUTE', {
+      context: { team: ['cto', 'qa'] },
+    });
+    expect(result.valid).toBe(true);
+    expect(result.state).toBe('executing');
+  });
+
+  it('guard가 false를 반환하면 transition 거부', () => {
+    const result = projectMachine.transition('approved', 'EXECUTE', {
+      context: { team: [] },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.state).toBe('approved');
+    expect(result.error).toMatch(/guard/i);
+  });
+
+  it('guard 없는 transition은 항상 통과', () => {
+    const result = projectMachine.transition('approved', 'REJECT');
+    expect(result.valid).toBe(true);
+    expect(result.state).toBe('planning');
+  });
+});
+
+describe('defineStateMachine — 헬퍼', () => {
+  it('canTransition: target 도달 가능 여부', () => {
+    expect(projectMachine.canTransition('planning', 'APPROVE')).toBe(true);
+    expect(projectMachine.canTransition('planning', 'COMPLETE')).toBe(false);
+  });
+
+  it('availableEvents: 현재 state에서 가능한 events', () => {
+    expect(projectMachine.availableEvents('planning')).toEqual(
+      expect.arrayContaining(['APPROVE', 'RESET']),
+    );
+    expect(projectMachine.availableEvents('completed')).toEqual(['MODIFY']);
+  });
+
+  it('reachableStates: 한 step으로 도달 가능한 states', () => {
+    expect(projectMachine.reachableStates('planning')).toEqual(
+      expect.arrayContaining(['approved', 'planning']),
+    );
+  });
+
+  it('allStates: 정의된 모든 state', () => {
+    expect(projectMachine.allStates()).toEqual([
+      'planning',
+      'approved',
+      'executing',
+      'reviewing',
+      'completed',
+    ]);
+  });
+});
+
+describe('defineStateMachine — 검증', () => {
+  it('initial이 states에 없으면 throw', () => {
+    expect(() =>
+      defineStateMachine({
+        initial: 'undefined-state',
+        states: { foo: { on: {} } },
+      }),
+    ).toThrow(/initial/i);
+  });
+
+  it('transition target이 정의되지 않은 state면 throw', () => {
+    expect(() =>
+      defineStateMachine({
+        initial: 'a',
+        states: {
+          a: { on: { GO: { target: 'nonexistent' } } },
+        },
+      }),
+    ).toThrow(/target/i);
+  });
+
+  it('states가 비어있으면 throw', () => {
+    expect(() => defineStateMachine({ initial: 'a', states: {} })).toThrow(/state/i);
+  });
+});
+
+describe('defineStateMachine — actions (선택적 부수효과)', () => {
+  it('transition에 actions 함수가 있으면 결과에 액션 result를 포함', () => {
+    const machine = defineStateMachine({
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            GO: {
+              target: 'b',
+              actions: (ctx) => [{ type: 'log', data: ctx.data }],
+            },
+          },
+        },
+        b: { on: {} },
+      },
+    });
+    const result = machine.transition('a', 'GO', { context: { data: 'hello' } });
+    expect(result.valid).toBe(true);
+    expect(result.actions).toEqual([{ type: 'log', data: 'hello' }]);
+  });
+
+  it('actions 함수가 없으면 빈 배열', () => {
+    const result = projectMachine.transition('planning', 'APPROVE');
+    expect(result.actions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

오케스트레이션 일반화 Phase 2 — `state-machine.js`의 암묵적 if-else 분기를
명시적 transition 정의로 표현 가능하게 하는 기반.

이 PR은 **새 모듈만 추가**한다. 기존 `state-machine.js` 마이그레이션은 후속 PR.

## Module: scripts/lib/core/state-machine-dsl.js

```js
const machine = defineStateMachine({
  initial: 'planning',
  states: {
    planning: {
      on: {
        APPROVE: { target: 'approved', guard: (ctx) => ctx.team.length > 0 },
        RESET: { target: 'planning' },
      },
    },
    ...
  },
});

machine.transition('planning', 'APPROVE', { context: { team: [...] } });
// → { valid: true, state: 'approved', actions: [] }
```

- `defineStateMachine({ initial, states })` — 정의 시점 검증
- `transition(state, event, { context })` — guard/actions 안전 실행
- 헬퍼: `canTransition`, `availableEvents`, `reachableStates`, `allStates`
- 외부 의존성 0 (xstate 미사용)

## Background

LangGraph/xstate 같은 산업 표준은 명시적 statechart로 상태 흐름을 표현한다.
GVC의 `state-machine.js:268-364`는 함수 기반 if-else 분기로 실제 transition이
코드에 흩어져 있어 검증/시각화/테스트가 어렵다.

이 DSL 위에 마이그레이션하면:
- VALID_TRANSITIONS을 selectable 정의로
- 상태별 가능한 액션을 자동 도출
- 검증 규칙(guards)을 transition별로 명시

## Test plan

- [x] `tests/state-machine-dsl.test.js` 17건 (기본 transition, guard, 헬퍼, 검증, actions)
- [x] 전체 2588 통과 (+17), 회귀 0
- [x] `npm run lint` 통과

## 다음 단계

- 기존 `state-machine.js`의 VALID_TRANSITIONS을 DSL로 이전
- handleQualityGate 등 동적 분기를 guard/actions로 표현

🤖 Generated with [Claude Code](https://claude.com/claude-code)