### PR TITLE
feat(cost): LLM 비용 메터링 + 캐시 적중률 (orchestration Phase 3)

### DIFF
--- a/scripts/lib/llm/cost-tracker.js
+++ b/scripts/lib/llm/cost-tracker.js
@@ -1,0 +1,210 @@
+/**
+ * cost-tracker — LLM 호출 비용 메터링 + 예산 추적
+ *
+ * 토큰 사용량을 프로바이더별 가격표로 USD 환산.
+ * Phase 3 일반화의 핵심 — oh-my-claudecode Ecomode 같은 비용 가시화.
+ *
+ * 외부 의존성 0. callLLM에서 호출하면 자동 누적.
+ */
+
+/**
+ * 프로바이더별 가격표 (USD per million tokens).
+ *
+ * 출처: 각 프로바이더 공식 가격 (2026-04 기준).
+ * 가격이 자주 바뀌므로 업데이트 필요.
+ */
+export const PROVIDER_PRICING = Object.freeze({
+  claude: Object.freeze({
+    // alias
+    opus: {
+      inputPerMillion: 15,
+      outputPerMillion: 75,
+      cacheReadPerMillion: 1.5,
+      cacheWritePerMillion: 18.75,
+    },
+    sonnet: {
+      inputPerMillion: 3,
+      outputPerMillion: 15,
+      cacheReadPerMillion: 0.3,
+      cacheWritePerMillion: 3.75,
+    },
+    haiku: {
+      inputPerMillion: 1,
+      outputPerMillion: 5,
+      cacheReadPerMillion: 0.1,
+      cacheWritePerMillion: 1.25,
+    },
+    // 정식 모델 ID
+    'claude-opus-4-7': {
+      inputPerMillion: 15,
+      outputPerMillion: 75,
+      cacheReadPerMillion: 1.5,
+      cacheWritePerMillion: 18.75,
+    },
+    'claude-sonnet-4-6': {
+      inputPerMillion: 3,
+      outputPerMillion: 15,
+      cacheReadPerMillion: 0.3,
+      cacheWritePerMillion: 3.75,
+    },
+    'claude-haiku-4-5-20251001': {
+      inputPerMillion: 1,
+      outputPerMillion: 5,
+      cacheReadPerMillion: 0.1,
+      cacheWritePerMillion: 1.25,
+    },
+  }),
+  openai: Object.freeze({
+    'gpt-4o': { inputPerMillion: 2.5, outputPerMillion: 10 },
+    'gpt-4o-mini': { inputPerMillion: 0.15, outputPerMillion: 0.6 },
+    'gpt-5': { inputPerMillion: 5, outputPerMillion: 20 },
+  }),
+  gemini: Object.freeze({
+    'gemini-2.0-flash': { inputPerMillion: 0.1, outputPerMillion: 0.4 },
+    'gemini-2.0-pro': { inputPerMillion: 1.25, outputPerMillion: 5 },
+  }),
+});
+
+/**
+ * 토큰 사용량을 비용으로 환산한다 (USD).
+ *
+ * @param {string} provider
+ * @param {string} model
+ * @param {{ inputTokens?: number, outputTokens?: number, cacheReadInputTokens?: number, cacheCreationInputTokens?: number }} usage
+ * @returns {number} 비용 (USD)
+ */
+export function estimateCost(provider, model, usage = {}) {
+  const providerTable = PROVIDER_PRICING[provider];
+  if (!providerTable) return 0;
+  const pricing = providerTable[model];
+  if (!pricing) return 0;
+
+  const input = (usage.inputTokens || 0) / 1_000_000;
+  const output = (usage.outputTokens || 0) / 1_000_000;
+  const cacheRead = (usage.cacheReadInputTokens || 0) / 1_000_000;
+  const cacheWrite = (usage.cacheCreationInputTokens || 0) / 1_000_000;
+
+  let cost = input * pricing.inputPerMillion + output * pricing.outputPerMillion;
+  if (pricing.cacheReadPerMillion !== undefined) {
+    cost += cacheRead * pricing.cacheReadPerMillion;
+  }
+  if (pricing.cacheWritePerMillion !== undefined) {
+    cost += cacheWrite * pricing.cacheWritePerMillion;
+  }
+  return cost;
+}
+
+/**
+ * 비용 추적기를 생성한다.
+ *
+ * @param {object} [options]
+ * @param {number} [options.budgetUsd] - 누적 예산 한도 (USD). 초과 시 isOverBudget=true
+ * @param {(info: { totalCost: number, budgetUsd: number }) => void} [options.onBudgetExceeded] - 예산 초과 시점 콜백 (1회)
+ * @returns {{
+ *   record: (call: { provider: string, model: string, inputTokens?: number, outputTokens?: number, cacheReadInputTokens?: number, cacheCreationInputTokens?: number }) => void,
+ *   getStats: () => object,
+ *   reset: () => void,
+ * }}
+ */
+export function createCostTracker(options = {}) {
+  const budgetUsd = options.budgetUsd;
+  const onBudgetExceeded = options.onBudgetExceeded;
+
+  let totalCalls = 0;
+  let totalCost = 0;
+  let cacheHitTokens = 0;
+  let cacheCreationTokens = 0;
+  let totalUncachedInputTokens = 0;
+  const byProvider = new Map();
+  const byModel = new Map();
+  let budgetExceededFired = false;
+
+  function bumpProvider(provider, call, cost) {
+    const entry = byProvider.get(provider) || {
+      calls: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+    };
+    entry.calls++;
+    entry.inputTokens += call.inputTokens || 0;
+    entry.outputTokens += call.outputTokens || 0;
+    entry.cost += cost;
+    byProvider.set(provider, entry);
+  }
+
+  function bumpModel(model, call, cost) {
+    const entry = byModel.get(model) || {
+      calls: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+    };
+    entry.calls++;
+    entry.inputTokens += call.inputTokens || 0;
+    entry.outputTokens += call.outputTokens || 0;
+    entry.cost += cost;
+    byModel.set(model, entry);
+  }
+
+  return {
+    record(call) {
+      const cost = estimateCost(call.provider, call.model, call);
+      totalCalls++;
+      totalCost += cost;
+      cacheHitTokens += call.cacheReadInputTokens || 0;
+      cacheCreationTokens += call.cacheCreationInputTokens || 0;
+      totalUncachedInputTokens += call.inputTokens || 0;
+      bumpProvider(call.provider, call, cost);
+      bumpModel(call.model, call, cost);
+
+      if (
+        budgetUsd !== undefined &&
+        totalCost > budgetUsd &&
+        !budgetExceededFired &&
+        typeof onBudgetExceeded === 'function'
+      ) {
+        budgetExceededFired = true;
+        try {
+          onBudgetExceeded({ totalCost, budgetUsd });
+        } catch {
+          // 콜백 에러는 무시 (모니터링 채널만 영향)
+        }
+      }
+    },
+
+    getStats() {
+      const cacheTotal = cacheHitTokens + totalUncachedInputTokens;
+      const hitRate = cacheTotal > 0 ? cacheHitTokens / cacheTotal : 0;
+
+      const stats = {
+        totalCalls,
+        totalCost,
+        byProvider: {},
+        byModel: {},
+        cacheStats: {
+          hitTokens: cacheHitTokens,
+          creationTokens: cacheCreationTokens,
+          hitRate,
+        },
+        isOverBudget: budgetUsd !== undefined && totalCost > budgetUsd,
+        budgetRemainingUsd: budgetUsd !== undefined ? budgetUsd - totalCost : null,
+      };
+
+      for (const [k, v] of byProvider) stats.byProvider[k] = { ...v };
+      for (const [k, v] of byModel) stats.byModel[k] = { ...v };
+      return stats;
+    },
+
+    reset() {
+      totalCalls = 0;
+      totalCost = 0;
+      cacheHitTokens = 0;
+      cacheCreationTokens = 0;
+      totalUncachedInputTokens = 0;
+      byProvider.clear();
+      byModel.clear();
+      budgetExceededFired = false;
+    },
+  };
+}

--- a/scripts/lib/llm/llm-provider.js
+++ b/scripts/lib/llm/llm-provider.js
@@ -9,6 +9,7 @@
 import { loadAuth } from './auth-manager.js';
 import { callGeminiCli } from './gemini-bridge.js';
 import { createLLMPool } from './llm-pool.js';
+import { createCostTracker } from './cost-tracker.js';
 import { config } from '../core/config.js';
 import { AppError, inputError, notFoundError } from '../core/validators.js';
 import { truncateText } from '../core/text-utils.js';
@@ -51,6 +52,19 @@ const llmPool = createLLMPool({
 /** 테스트/관측용 풀 통계 — getStats() 노출. */
 export function getLLMPoolStats() {
   return llmPool.getStats();
+}
+
+/** 글로벌 비용 추적기. callLLM이 응답 토큰 사용량을 자동 record. */
+const costTracker = createCostTracker();
+
+/** 테스트/관측용 비용 통계 — totalCost, byProvider, cacheStats 등. */
+export function getCostStats() {
+  return costTracker.getStats();
+}
+
+/** 테스트용 — 비용 통계 초기화. */
+export function resetCostStats() {
+  costTracker.reset();
 }
 
 /**
@@ -120,7 +134,16 @@ async function _executeLLMCall(providerId, prompt, options, auth) {
         lastError = err;
       } else {
         const data = await response.json();
-        return parseProviderResponse(providerId, data, model);
+        const result = parseProviderResponse(providerId, data, model);
+        costTracker.record({
+          provider: providerId,
+          model: result.model,
+          inputTokens: result.inputTokens || 0,
+          outputTokens: result.outputTokens || 0,
+          cacheReadInputTokens: result.cacheReadInputTokens || 0,
+          cacheCreationInputTokens: result.cacheCreationInputTokens || 0,
+        });
+        return result;
       }
     } catch (err) {
       // 이미 재시도 불가로 판정된 에러는 즉시 재throw

--- a/tests/cost-tracker.test.js
+++ b/tests/cost-tracker.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createCostTracker,
+  estimateCost,
+  PROVIDER_PRICING,
+} from '../scripts/lib/llm/cost-tracker.js';
+
+describe('PROVIDER_PRICING — 가격표', () => {
+  it('Claude/OpenAI/Gemini 주요 모델이 정의되어 있다', () => {
+    expect(PROVIDER_PRICING.claude).toBeDefined();
+    expect(PROVIDER_PRICING.openai).toBeDefined();
+    expect(PROVIDER_PRICING.gemini).toBeDefined();
+
+    expect(PROVIDER_PRICING.claude['claude-sonnet-4-6']).toMatchObject({
+      inputPerMillion: expect.any(Number),
+      outputPerMillion: expect.any(Number),
+    });
+  });
+
+  it('alias model name (sonnet/opus/haiku)도 매칭된다', () => {
+    expect(PROVIDER_PRICING.claude.sonnet).toBeDefined();
+    expect(PROVIDER_PRICING.claude.opus).toBeDefined();
+    expect(PROVIDER_PRICING.claude.haiku).toBeDefined();
+  });
+});
+
+describe('estimateCost', () => {
+  it('input/output 토큰 × 가격으로 비용 계산', () => {
+    const cost = estimateCost('claude', 'sonnet', {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    });
+    const pricing = PROVIDER_PRICING.claude.sonnet;
+    expect(cost).toBeCloseTo(pricing.inputPerMillion + pricing.outputPerMillion, 6);
+  });
+
+  it('알 수 없는 모델은 0 반환 + warning', () => {
+    const cost = estimateCost('claude', 'mystery-model', {
+      inputTokens: 1000,
+      outputTokens: 500,
+    });
+    expect(cost).toBe(0);
+  });
+
+  it('cacheReadInputTokens가 있으면 cached 가격 적용', () => {
+    const cost = estimateCost('claude', 'sonnet', {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 1_000_000,
+    });
+    const pricing = PROVIDER_PRICING.claude.sonnet;
+    if (pricing.cacheReadPerMillion !== undefined) {
+      expect(cost).toBeCloseTo(pricing.cacheReadPerMillion, 6);
+    }
+  });
+
+  it('cacheCreationInputTokens가 있으면 cache write 가격 적용', () => {
+    const cost = estimateCost('claude', 'sonnet', {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 1_000_000,
+    });
+    const pricing = PROVIDER_PRICING.claude.sonnet;
+    if (pricing.cacheWritePerMillion !== undefined) {
+      expect(cost).toBeCloseTo(pricing.cacheWritePerMillion, 6);
+    }
+  });
+});
+
+describe('createCostTracker', () => {
+  let tracker;
+  beforeEach(() => {
+    tracker = createCostTracker();
+  });
+
+  it('record + getStats 기본 사이클', () => {
+    tracker.record({
+      provider: 'claude',
+      model: 'sonnet',
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    });
+    const stats = tracker.getStats();
+    expect(stats.totalCalls).toBe(1);
+    expect(stats.totalCost).toBeGreaterThan(0);
+    expect(stats.byProvider.claude.calls).toBe(1);
+    expect(stats.byProvider.claude.inputTokens).toBe(1000);
+    expect(stats.byProvider.claude.outputTokens).toBe(500);
+  });
+
+  it('여러 record 누적', () => {
+    for (let i = 0; i < 5; i++) {
+      tracker.record({
+        provider: 'claude',
+        model: 'sonnet',
+        inputTokens: 100,
+        outputTokens: 50,
+      });
+    }
+    const stats = tracker.getStats();
+    expect(stats.totalCalls).toBe(5);
+    expect(stats.byProvider.claude.inputTokens).toBe(500);
+    expect(stats.byProvider.claude.outputTokens).toBe(250);
+  });
+
+  it('프로바이더/모델별 분리 기록', () => {
+    tracker.record({ provider: 'claude', model: 'sonnet', inputTokens: 100, outputTokens: 50 });
+    tracker.record({ provider: 'openai', model: 'gpt-4o', inputTokens: 200, outputTokens: 100 });
+    const stats = tracker.getStats();
+    expect(stats.byProvider.claude.calls).toBe(1);
+    expect(stats.byProvider.openai.calls).toBe(1);
+    expect(stats.byModel.sonnet).toBeDefined();
+    expect(stats.byModel['gpt-4o']).toBeDefined();
+  });
+
+  it('budget 한도 초과 시 isOverBudget true', () => {
+    const limited = createCostTracker({ budgetUsd: 0.001 });
+    limited.record({
+      provider: 'claude',
+      model: 'opus',
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    });
+    const stats = limited.getStats();
+    expect(stats.isOverBudget).toBe(true);
+    expect(stats.budgetRemainingUsd).toBeLessThan(0);
+  });
+
+  it('cache hit rate 추적', () => {
+    tracker.record({
+      provider: 'claude',
+      model: 'sonnet',
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheCreationInputTokens: 200,
+      cacheReadInputTokens: 800,
+    });
+    const stats = tracker.getStats();
+    expect(stats.cacheStats.hitTokens).toBe(800);
+    expect(stats.cacheStats.creationTokens).toBe(200);
+    // hit rate = read / (read + uncached input)
+    expect(stats.cacheStats.hitRate).toBeCloseTo(800 / (800 + 1000), 4);
+  });
+
+  it('reset()으로 통계 초기화', () => {
+    tracker.record({ provider: 'claude', model: 'sonnet', inputTokens: 100, outputTokens: 50 });
+    tracker.reset();
+    const stats = tracker.getStats();
+    expect(stats.totalCalls).toBe(0);
+    expect(stats.totalCost).toBe(0);
+  });
+});
+
+describe('createCostTracker — onBudgetExceeded 콜백', () => {
+  it('budget 초과 시점에 콜백이 실행된다', () => {
+    let exceeded = null;
+    const limited = createCostTracker({
+      budgetUsd: 0.0001,
+      onBudgetExceeded: (info) => {
+        exceeded = info;
+      },
+    });
+    limited.record({
+      provider: 'claude',
+      model: 'opus',
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    });
+    expect(exceeded).not.toBeNull();
+    expect(exceeded.totalCost).toBeGreaterThan(0.0001);
+    expect(exceeded.budgetUsd).toBe(0.0001);
+  });
+
+  it('budget 미초과 시 콜백 호출 안 함', () => {
+    let called = false;
+    const limited = createCostTracker({
+      budgetUsd: 1000,
+      onBudgetExceeded: () => {
+        called = true;
+      },
+    });
+    limited.record({ provider: 'claude', model: 'sonnet', inputTokens: 100, outputTokens: 50 });
+    expect(called).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

오케스트레이션 일반화 Phase 3 — oh-my-claudecode Ecomode 같은 비용 가시화의 첫 단계.
자동 폴백 라우팅(429 시 ModelSelector.selectFallback)은 후속 PR.

## Module: scripts/lib/llm/cost-tracker.js

- **PROVIDER_PRICING**: Claude/OpenAI/Gemini 주요 모델 가격표 (USD per million)
  - Claude: opus/sonnet/haiku alias + 정식 ID 모두 지원
  - cache read/write 가격 별도
- **estimateCost(provider, model, usage)**: input/output + cache 토큰 → USD
- **createCostTracker({ budgetUsd, onBudgetExceeded })**:
  - record/getStats/reset
  - 프로바이더별/모델별 분리 통계
  - 캐시 적중률 (`hitRate = cacheRead / (cacheRead + uncachedInput)`)
  - 예산 한도 + 초과 시 콜백 (1회)

## llm-provider 통합

- 글로벌 `costTracker` 인스턴스
- `callLLM` 응답 시 자동 record (input/output/cache 토큰 모두)
- `getCostStats()` / `resetCostStats()` export

## Background

Phase 1에서 `llm-pool`, `ModelSelector`를 도입했지만 비용 가시화는 부재.
oh-my-claudecode는 토큰 30-50% 절약을 광고하는데 측정 도구 없이는 검증 불가.

이 PR로:
- 누적 비용을 USD로 추적
- 캐시 적중률로 prompt caching 효과 측정
- 예산 한도 설정 가능 → CI/cron 자율 파이프라인에서 폭주 차단

## Test plan

- [x] `tests/cost-tracker.test.js` 14건 (가격표, estimate, 누적, 분리, 캐시 통계, 예산 콜백)
- [x] 전체 2627 통과 (+14), 회귀 0
- [x] `npm run lint` 통과

## 다음 단계 (Phase 3 잔여)

- 자동 폴백 라우팅: 429 시 `ModelSelector.selectFallback`로 다음 모델 시도
- 분산 워커 풀 (BullMQ 등) — 외부 의존성 추가 필요, 별도 합의

🤖 Generated with [Claude Code](https://claude.com/claude-code)