### PR TITLE
feat(llm): 자동 모델 폴백 라우팅 (orchestration Phase 3)

### DIFF
--- a/scripts/lib/llm/llm-fallback.js
+++ b/scripts/lib/llm/llm-fallback.js
@@ -1,0 +1,116 @@
+/**
+ * llm-fallback — 자동 모델 폴백 라우팅
+ *
+ * 첫 모델 호출이 retryable 에러로 실패하면 ModelSelector.selectFallback로
+ * 다음 모델로 자동 전환한다. opus → sonnet → haiku 순.
+ *
+ * 비-재시도 에러(401, 403 등 권한)는 즉시 throw하여 폴백 시도 안 함.
+ *
+ * 외부 의존성 0. callLLM을 인자로 받아 dependency injection.
+ */
+
+import { createModelSelector, DEFAULT_FALLBACK_CHAIN } from './model-selector.js';
+import { callLLM as defaultCallLLM } from './llm-provider.js';
+import { config } from '../core/config.js';
+
+const RETRYABLE_STATUS_CODES = new Set(config.http.retryableCodes);
+
+const defaultSelector = createModelSelector('default');
+
+function isFallbackable(err) {
+  if (!err) return false;
+  if (typeof err.statusCode === 'number') return RETRYABLE_STATUS_CODES.has(err.statusCode);
+  // statusCode 없는 에러 (네트워크 등)는 폴백 시도 — llm-provider가 자체 재시도 후 던진 것
+  return true;
+}
+
+function buildModelChain(startModel, explicitChain) {
+  if (Array.isArray(explicitChain) && explicitChain.length > 0) {
+    return explicitChain;
+  }
+  // selectFallback으로 체인 구성: startModel → fallback → fallback → ...
+  const chain = [startModel];
+  let current = startModel;
+  while (true) {
+    const next = defaultSelector.selectFallback(current);
+    if (!next || chain.includes(next)) break;
+    chain.push(next);
+    current = next;
+  }
+  // startModel이 DEFAULT_FALLBACK_CHAIN에 없으면 단일 시도만
+  if (chain.length === 1 && !DEFAULT_FALLBACK_CHAIN.includes(startModel)) {
+    return [startModel];
+  }
+  return chain;
+}
+
+/**
+ * 모델 폴백을 자동 적용하여 LLM을 호출한다.
+ *
+ * @param {string} provider - 'claude' | 'openai' | 'gemini'
+ * @param {string} prompt
+ * @param {object} options
+ * @param {string} [options.model] - 시작 모델
+ * @param {string[]} [options.modelChain] - 명시적 폴백 체인 (model 무시)
+ * @param {(info: { from: string, to: string, reason: string }) => void} [options.onFallback] - 폴백 시점 콜백
+ * @param {Function} [options.callLLM] - DI용 callLLM (기본: llm-provider.callLLM)
+ * @param {number} [options.maxTokens] - 단일 시도 옵션 (전달)
+ * @param {number} [options.timeout] - 단일 시도 옵션 (전달)
+ * @param {string} [options.systemMessage]
+ * @returns {Promise<{ text: string, model: string, fallbackChain: string[], fallbackUsed: boolean, ... }>}
+ */
+export async function callLLMWithFallback(provider, prompt, options = {}) {
+  const callLLM = options.callLLM || defaultCallLLM;
+  const startModel = options.model;
+  const chain = buildModelChain(startModel, options.modelChain);
+
+  const usedChain = [];
+  let lastError;
+
+  // callLLM에 전달할 옵션 (callLLM/onFallback/modelChain은 제거)
+  const passOptions = { ...options };
+  delete passOptions.callLLM;
+  delete passOptions.onFallback;
+  delete passOptions.modelChain;
+
+  for (let i = 0; i < chain.length; i++) {
+    const model = chain[i];
+    usedChain.push(model);
+
+    try {
+      const result = await callLLM(provider, prompt, { ...passOptions, model });
+      return {
+        ...result,
+        fallbackChain: usedChain,
+        fallbackUsed: usedChain.length > 1,
+      };
+    } catch (err) {
+      lastError = err;
+
+      if (!isFallbackable(err)) {
+        // 권한 에러 등은 즉시 throw — 폴백 의미 없음
+        throw err;
+      }
+
+      // 마지막 모델 실패 시 throw
+      if (i === chain.length - 1) throw err;
+
+      // 다음 모델로 폴백
+      const nextModel = chain[i + 1];
+      if (typeof options.onFallback === 'function') {
+        try {
+          options.onFallback({
+            from: model,
+            to: nextModel,
+            reason: err.message || `status ${err.statusCode}`,
+          });
+        } catch {
+          // 콜백 에러는 무시
+        }
+      }
+    }
+  }
+
+  // 도달 불가 (마지막 모델 실패는 위에서 throw)
+  throw lastError;
+}

--- a/tests/llm-fallback.test.js
+++ b/tests/llm-fallback.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { callLLMWithFallback } from '../scripts/lib/llm/llm-fallback.js';
+import { AppError } from '../scripts/lib/core/validators.js';
+
+function makeRetryableError(status = 429) {
+  const err = new AppError(`mock ${status}`, 'SYSTEM_ERROR');
+  err.statusCode = status;
+  return err;
+}
+
+describe('callLLMWithFallback', () => {
+  let callLLM;
+  beforeEach(() => {
+    callLLM = vi.fn();
+  });
+
+  it('첫 모델 성공 시 그대로 반환 (폴백 안 함)', async () => {
+    callLLM.mockResolvedValueOnce({ text: 'ok', model: 'opus', tokenCount: 100 });
+    const result = await callLLMWithFallback('claude', 'hello', {
+      model: 'opus',
+      callLLM,
+    });
+    expect(result.text).toBe('ok');
+    expect(result.model).toBe('opus');
+    expect(result.fallbackChain).toEqual(['opus']);
+    expect(result.fallbackUsed).toBe(false);
+    expect(callLLM).toHaveBeenCalledTimes(1);
+  });
+
+  it('첫 모델 retryable 에러 시 다음 모델로 폴백', async () => {
+    callLLM
+      .mockRejectedValueOnce(makeRetryableError(429))
+      .mockResolvedValueOnce({ text: 'ok-from-sonnet', model: 'sonnet', tokenCount: 80 });
+
+    const result = await callLLMWithFallback('claude', 'hello', {
+      model: 'opus',
+      callLLM,
+    });
+
+    expect(result.text).toBe('ok-from-sonnet');
+    expect(result.model).toBe('sonnet');
+    expect(result.fallbackChain).toEqual(['opus', 'sonnet']);
+    expect(result.fallbackUsed).toBe(true);
+    expect(callLLM).toHaveBeenCalledTimes(2);
+  });
+
+  it('모든 모델 실패 시 최종 에러를 throw', async () => {
+    callLLM
+      .mockRejectedValueOnce(makeRetryableError(503))
+      .mockRejectedValueOnce(makeRetryableError(503))
+      .mockRejectedValueOnce(makeRetryableError(503));
+
+    await expect(
+      callLLMWithFallback('claude', 'hello', { model: 'opus', callLLM }),
+    ).rejects.toThrow(/503/);
+    expect(callLLM).toHaveBeenCalledTimes(3);
+  });
+
+  it('비-재시도 에러(401)는 즉시 throw, 폴백 안 함', async () => {
+    const err = new AppError('mock 401 unauthorized', 'SYSTEM_ERROR');
+    err.statusCode = 401;
+    callLLM.mockRejectedValueOnce(err);
+
+    await expect(
+      callLLMWithFallback('claude', 'hello', { model: 'opus', callLLM }),
+    ).rejects.toThrow(/401/);
+    expect(callLLM).toHaveBeenCalledTimes(1);
+  });
+
+  it('explicit modelChain을 따른다', async () => {
+    callLLM
+      .mockRejectedValueOnce(makeRetryableError(429))
+      .mockResolvedValueOnce({ text: 'tiny', model: 'haiku', tokenCount: 10 });
+
+    const result = await callLLMWithFallback('claude', 'hello', {
+      modelChain: ['opus', 'haiku'], // sonnet 건너뛰기
+      callLLM,
+    });
+
+    expect(result.fallbackChain).toEqual(['opus', 'haiku']);
+    expect(result.fallbackUsed).toBe(true);
+    expect(callLLM).toHaveBeenCalledTimes(2);
+    expect(callLLM.mock.calls[1][2]).toMatchObject({ model: 'haiku' });
+  });
+
+  it('알 수 없는 모델로 시작하면 폴백 체인 없이 호출 (단일 시도)', async () => {
+    callLLM.mockRejectedValueOnce(makeRetryableError(429));
+    await expect(
+      callLLMWithFallback('claude', 'hello', { model: 'mystery-model', callLLM }),
+    ).rejects.toThrow(/429/);
+    expect(callLLM).toHaveBeenCalledTimes(1);
+  });
+
+  it('onFallback 콜백이 폴백 시점에 실행된다', async () => {
+    callLLM
+      .mockRejectedValueOnce(makeRetryableError(429))
+      .mockResolvedValueOnce({ text: 'ok', model: 'sonnet', tokenCount: 50 });
+
+    const events = [];
+    await callLLMWithFallback('claude', 'hello', {
+      model: 'opus',
+      callLLM,
+      onFallback: (info) => events.push(info),
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      from: 'opus',
+      to: 'sonnet',
+      reason: expect.stringMatching(/429/),
+    });
+  });
+
+  it('fallback 시 options(maxTokens 등)는 보존된다', async () => {
+    callLLM
+      .mockRejectedValueOnce(makeRetryableError(429))
+      .mockResolvedValueOnce({ text: 'ok', model: 'sonnet', tokenCount: 50 });
+
+    await callLLMWithFallback('claude', 'hello', {
+      model: 'opus',
+      maxTokens: 8192,
+      timeout: 30_000,
+      callLLM,
+    });
+
+    expect(callLLM.mock.calls[1][2]).toMatchObject({
+      model: 'sonnet',
+      maxTokens: 8192,
+      timeout: 30_000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

오케스트레이션 일반화 Phase 3 잔여 — 첫 모델이 retryable 에러로 실패하면
`ModelSelector.selectFallback`로 다음 모델로 자동 전환 (opus → sonnet → haiku).

## API: callLLMWithFallback

```js
import { callLLMWithFallback } from 'scripts/lib/llm/llm-fallback.js';

const result = await callLLMWithFallback('claude', prompt, {
  model: 'opus',
  onFallback: ({ from, to, reason }) => console.log(`${from} → ${to}: ${reason}`),
});

// result.fallbackChain: ['opus', 'sonnet']
// result.fallbackUsed: true (또는 false)
```

- `options.model` 시작, `selectFallback` 체인 따라 폴백
- `options.modelChain`으로 명시적 체인 지정 가능 (예: `['opus', 'haiku']` — sonnet 건너뛰기)
- retryable 상태(429, 5xx) 또는 statusCode 없는 네트워크 에러만 폴백
- 401/403 등 권한 에러는 즉시 throw (폴백 무의미)
- 결과에 `fallbackChain`, `fallbackUsed` 포함
- `onFallback` 콜백 (시점/이유 보고)
- DI: `options.callLLM`로 테스트 가능

## 호환성

기존 `callLLM` 시그니처 변경 **0**. 새 진입점만 추가.
점진적으로 호출자가 `callLLMWithFallback`로 마이그레이션 가능.

## Background

Phase 1에서 `ModelSelector.selectFallback`을 추가했지만 실제로 사용처 없었다.
Phase 3 비용 메터링과 함께 — 비싼 모델이 rate limit 걸려도 cheaper 모델로 자동 전환되어
서비스 연속성 + 비용 절감.

## Test plan

- [x] `tests/llm-fallback.test.js` 8건 (성공/폴백/모두 실패/비-재시도/명시적 체인/알 수 없는 모델/콜백/옵션 보존)
- [x] 전체 2635 통과 (+8), 회귀 0
- [x] `npm run lint` 통과

## Phase 3 완료 후 다음

- 기존 호출자(Discusser/Executor)에 callLLMWithFallback 적용 (별도 PR)
- 분산 워커 풀 (BullMQ 등) — 외부 의존성 추가 필요, 별도 합의

🤖 Generated with [Claude Code](https://claude.com/claude-code)