### PR TITLE
refactor(sdk): Discusser/Executor가 callLLMWithFallback을 사용 (마이그레이션 B)

### DIFF
--- a/src/discusser.js
+++ b/src/discusser.js
@@ -13,7 +13,9 @@ import {
   parseReviewOutput,
   selectDiscussionReviewers,
 } from '../scripts/lib/engine/orchestrator.js';
-import { callLLM } from '../scripts/lib/llm/llm-provider.js';
+// callLLMWithFallback을 callLLM 별칭으로 사용 — 첫 모델이 429/5xx로 실패하면
+// ModelSelector.selectFallback 체인 따라 자동 다음 모델 시도. 시그니처/응답 호환.
+import { callLLMWithFallback as callLLM } from '../scripts/lib/llm/llm-fallback.js';
 import { config } from '../scripts/lib/core/config.js';
 import { DEFAULTS } from './defaults.js';
 

--- a/src/executor.js
+++ b/src/executor.js
@@ -27,7 +27,9 @@ import {
   orchestrateConsultation,
   enrichTaskOutputWithConsultation,
 } from '../scripts/lib/engine/expert-consultation.js';
-import { callLLM } from '../scripts/lib/llm/llm-provider.js';
+// callLLMWithFallback을 callLLM 별칭으로 사용 — 첫 모델이 429/5xx로 실패하면
+// ModelSelector.selectFallback 체인 따라 자동 다음 모델 시도. 시그니처/응답 호환.
+import { callLLMWithFallback as callLLM } from '../scripts/lib/llm/llm-fallback.js';
 import {
   createPhaseWorktree,
   removePhaseWorktree,


### PR DESCRIPTION
## Summary

오케스트레이션 일반화 마이그레이션 작업 **B** — SDK 진입점(Discusser, Executor)에
`callLLMWithFallback`을 적용하여 첫 모델 실패 시 자동 폴백.

## 변경

```diff
- import { callLLM } from '../scripts/lib/llm/llm-provider.js';
+ import { callLLMWithFallback as callLLM } from '../scripts/lib/llm/llm-fallback.js';
```

import 별칭 한 줄 변경. 본문 코드 변경 **0**. 시그니처/응답 완전 호환.

## 효과

- 첫 모델(예: opus) 호출이 **429 / 5xx / 네트워크 에러**로 실패 시
  `ModelSelector.selectFallback` 체인 따라 자동 다음 모델 (opus → sonnet → haiku) 시도
- **401 / 403** 등 권한 에러는 즉시 throw (기존과 동일)
- consultation / review-conversation 콜백에 전달하는 callLLM도 동일하게 폴백 적용
- 응답 객체에 `fallbackChain` / `fallbackUsed` 추가되지만 기존 호출자는 무시 가능

## Test plan

- [x] 전체 2635 통과, 회귀 0
- [x] mock된 `callLLM`이 fallback 모듈을 통해 호출되어 기존 SDK 테스트 (executor/discusser) 그대로 작동
- [x] `npm run lint` 통과

## 후속 작업

- **C**: `executionState.journal[]` → `journal.jsonl` 마이그레이션
- **D**: `state-machine.js` `VALID_TRANSITIONS` → `state-machine-dsl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)