### PR TITLE
feat(journal): migrate-journal 커맨드 — journal[] → jsonl 일괄 이전 (마이그레이션 C-1)

### DIFF
--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -27,6 +27,7 @@ const COMMAND_MAP = {
   'create-project': 'project',
   'get-project': 'project',
   'list-projects': 'project',
+  'migrate-journal': 'project',
   'update-status': 'project',
   'set-team': 'project',
   'execution-progress': 'project',

--- a/scripts/handlers/project.js
+++ b/scripts/handlers/project.js
@@ -11,6 +11,7 @@ import {
   addModifyEntry,
   addProjectTasks,
 } from '../lib/project/project-manager.js';
+import { migrateAllJournals } from '../lib/project/journal-migration.js';
 import { generateReport } from '../lib/output/report-generator.js';
 import { scanCodebase } from '../lib/project/codebase-scanner.js';
 import {
@@ -80,6 +81,13 @@ export const commands = {
   'list-projects': async () => {
     const projects = await listProjects();
     output(projects);
+  },
+
+  'migrate-journal': async () => {
+    const opts = parseArgs(args);
+    const dryRun = opts['dry-run'] === true || opts['dry-run'] === 'true';
+    const result = await migrateAllJournals({ dryRun });
+    output(result);
   },
 
   'update-status': async () => {

--- a/scripts/lib/project/journal-migration.js
+++ b/scripts/lib/project/journal-migration.js
@@ -1,0 +1,179 @@
+/**
+ * journal-migration — 기존 project.json의 executionState.journal[]을 jsonl로 일괄 이전
+ *
+ * 일회성 마이그레이션 도구. 풀 마이그레이션 후 project.json의 journal 필드는 제거.
+ * dry-run 모드 + 손상 graceful skip + 이미 jsonl 있는 프로젝트 skip.
+ *
+ * 외부 의존성 0.
+ */
+
+import { readdir, readFile, writeFile } from 'fs/promises';
+import { resolve, dirname } from 'path';
+import { fileExists } from '../core/file-writer.js';
+import { appendJournalEntry, getJournalFilePath } from './journal.js';
+import { getProjectDir } from './project-manager.js';
+
+/**
+ * project-manager의 setBaseDir이 변경하는 baseDir과 동기화된 경로 추론.
+ * getProjectDir은 setBaseDir 영향을 받으므로 그 부모를 baseDir로 사용.
+ */
+function getBaseDir() {
+  return dirname(getProjectDir('__probe__'));
+}
+
+function isValidEntry(entry) {
+  return entry && typeof entry === 'object' && typeof entry.type === 'string';
+}
+
+async function readProjectFile(projectId, baseDir) {
+  const path = resolve(baseDir, projectId, 'project.json');
+  const raw = await readFile(path, 'utf-8');
+  return { project: JSON.parse(raw), path };
+}
+
+async function writeProjectFile(path, project) {
+  await writeFile(path, JSON.stringify(project, null, 2), 'utf-8');
+}
+
+/**
+ * 단일 프로젝트의 journal[]을 jsonl로 이전한다.
+ *
+ * @param {string} projectId
+ * @param {object} [options]
+ * @param {boolean} [options.dryRun=false]
+ * @param {string} [options.baseDir] - 테스트용 베이스 디렉토리 override
+ * @returns {Promise<{ migrated: boolean, entriesCount: number, skippedCount: number, dryRun: boolean, reason?: string }>}
+ */
+export async function migrateProjectJournal(projectId, options = {}) {
+  const { dryRun = false } = options;
+  const baseDir = options.baseDir || getBaseDir();
+
+  // 이미 jsonl이 있으면 skip — 데이터 손상 방지
+  const jsonlPath = getJournalFilePath(projectId);
+  if (await fileExists(jsonlPath)) {
+    return {
+      migrated: false,
+      entriesCount: 0,
+      skippedCount: 0,
+      dryRun,
+      reason: '이미 journal.jsonl이 존재합니다 (already exists)',
+    };
+  }
+
+  const { project, path: projectPath } = await readProjectFile(projectId, baseDir);
+  const journal = project?.executionState?.journal;
+
+  if (!Array.isArray(journal) || journal.length === 0) {
+    return {
+      migrated: false,
+      entriesCount: 0,
+      skippedCount: 0,
+      dryRun,
+      reason: 'executionState.journal이 비어있거나 없습니다',
+    };
+  }
+
+  // valid entry만 추출
+  const validEntries = [];
+  let skippedCount = 0;
+  for (const entry of journal) {
+    if (isValidEntry(entry)) validEntries.push(entry);
+    else skippedCount++;
+  }
+
+  if (validEntries.length === 0) {
+    return {
+      migrated: false,
+      entriesCount: 0,
+      skippedCount,
+      dryRun,
+      reason: 'valid entry가 없습니다',
+    };
+  }
+
+  if (dryRun) {
+    return {
+      migrated: true,
+      entriesCount: validEntries.length,
+      skippedCount,
+      dryRun: true,
+    };
+  }
+
+  // jsonl로 append
+  for (const entry of validEntries) {
+    await appendJournalEntry(projectId, entry);
+  }
+
+  // project.json에서 journal 필드 제거
+  if (project.executionState) {
+    delete project.executionState.journal;
+    await writeProjectFile(projectPath, project);
+  }
+
+  return {
+    migrated: true,
+    entriesCount: validEntries.length,
+    skippedCount,
+    dryRun: false,
+  };
+}
+
+/**
+ * 모든 프로젝트의 journal을 일괄 마이그레이션한다.
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.dryRun=false]
+ * @param {string} [options.baseDir]
+ * @returns {Promise<{ totalProjects: number, migratedCount: number, skippedCount: number, failedCount: number, failures: Array<{projectId, error}>, dryRun: boolean }>}
+ */
+export async function migrateAllJournals(options = {}) {
+  const { dryRun = false } = options;
+  const baseDir = options.baseDir || getBaseDir();
+
+  let dirs;
+  try {
+    dirs = await readdir(baseDir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return {
+        totalProjects: 0,
+        migratedCount: 0,
+        skippedCount: 0,
+        failedCount: 0,
+        failures: [],
+        dryRun,
+      };
+    }
+    throw err;
+  }
+
+  const projectIds = dirs
+    .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+    .map((d) => d.name);
+
+  let migratedCount = 0;
+  let skippedCount = 0;
+  let failedCount = 0;
+  const failures = [];
+
+  for (const projectId of projectIds) {
+    try {
+      const result = await migrateProjectJournal(projectId, { dryRun, baseDir });
+      if (result.migrated) migratedCount++;
+      else skippedCount++;
+    } catch (err) {
+      failedCount++;
+      failures.push({ projectId, error: err.message });
+    }
+  }
+
+  return {
+    totalProjects: projectIds.length,
+    migratedCount,
+    skippedCount,
+    failedCount,
+    failures,
+    dryRun,
+  };
+}

--- a/tests/journal-migration.test.js
+++ b/tests/journal-migration.test.js
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  migrateProjectJournal,
+  migrateAllJournals,
+} from '../scripts/lib/project/journal-migration.js';
+import { setBaseDir } from '../scripts/lib/project/project-manager.js';
+import { setJournalBaseDir } from '../scripts/lib/project/journal.js';
+
+let tmpDir;
+
+function createProject(id, projectData) {
+  const dir = join(tmpDir, id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'project.json'), JSON.stringify(projectData, null, 2));
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'gvc-migrate-'));
+  setBaseDir(tmpDir);
+  setJournalBaseDir(tmpDir);
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('migrateProjectJournal — 단일 프로젝트', () => {
+  it('executionState.journal[]을 jsonl로 이전한다', async () => {
+    createProject('proj-a', {
+      id: 'proj-a',
+      executionState: {
+        journal: [
+          { type: 'phase-start', phase: 1, timestamp: 1000 },
+          { type: 'task-complete', taskId: 'a', timestamp: 1100 },
+        ],
+      },
+    });
+
+    const result = await migrateProjectJournal('proj-a');
+    expect(result.migrated).toBe(true);
+    expect(result.entriesCount).toBe(2);
+
+    // jsonl 파일 생성 확인
+    const jsonlPath = join(tmpDir, 'proj-a', 'journal.jsonl');
+    expect(existsSync(jsonlPath)).toBe(true);
+    const lines = readFileSync(jsonlPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).type).toBe('phase-start');
+    expect(JSON.parse(lines[1]).type).toBe('task-complete');
+
+    // project.json에서 journal 필드 제거 확인
+    const projectAfter = JSON.parse(readFileSync(join(tmpDir, 'proj-a', 'project.json'), 'utf-8'));
+    expect(projectAfter.executionState.journal).toBeUndefined();
+  });
+
+  it('이미 jsonl이 있으면 skip', async () => {
+    createProject('proj-b', {
+      id: 'proj-b',
+      executionState: { journal: [{ type: 'a', timestamp: 1 }] },
+    });
+    const dir = join(tmpDir, 'proj-b');
+    writeFileSync(join(dir, 'journal.jsonl'), JSON.stringify({ type: 'existing' }) + '\n');
+
+    const result = await migrateProjectJournal('proj-b');
+    expect(result.migrated).toBe(false);
+    expect(result.reason).toMatch(/이미|already/i);
+
+    // jsonl은 그대로
+    const lines = readFileSync(join(tmpDir, 'proj-b', 'journal.jsonl'), 'utf-8')
+      .trim()
+      .split('\n');
+    expect(JSON.parse(lines[0]).type).toBe('existing');
+  });
+
+  it('journal이 없거나 비어있으면 skip', async () => {
+    createProject('proj-c', { id: 'proj-c', executionState: {} });
+    const result = await migrateProjectJournal('proj-c');
+    expect(result.migrated).toBe(false);
+    expect(result.entriesCount).toBe(0);
+  });
+
+  it('executionState 자체가 없으면 skip', async () => {
+    createProject('proj-d', { id: 'proj-d' });
+    const result = await migrateProjectJournal('proj-d');
+    expect(result.migrated).toBe(false);
+  });
+
+  it('dry-run 모드는 파일을 변경하지 않는다', async () => {
+    createProject('proj-e', {
+      id: 'proj-e',
+      executionState: {
+        journal: [{ type: 'phase-start', phase: 1, timestamp: 1 }],
+      },
+    });
+
+    const result = await migrateProjectJournal('proj-e', { dryRun: true });
+    expect(result.migrated).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.entriesCount).toBe(1);
+
+    expect(existsSync(join(tmpDir, 'proj-e', 'journal.jsonl'))).toBe(false);
+    const projectAfter = JSON.parse(readFileSync(join(tmpDir, 'proj-e', 'project.json'), 'utf-8'));
+    expect(projectAfter.executionState.journal).toHaveLength(1);
+  });
+
+  it('손상된 entry는 skip하고 valid만 이전 + 보고', async () => {
+    createProject('proj-f', {
+      id: 'proj-f',
+      executionState: {
+        journal: [
+          { type: 'good', timestamp: 1 },
+          'invalid-entry-string',
+          { /* type 누락 */ data: 'x', timestamp: 2 },
+          { type: 'good2', timestamp: 3 },
+        ],
+      },
+    });
+
+    const result = await migrateProjectJournal('proj-f');
+    expect(result.migrated).toBe(true);
+    expect(result.entriesCount).toBe(2);
+    expect(result.skippedCount).toBe(2);
+
+    const lines = readFileSync(join(tmpDir, 'proj-f', 'journal.jsonl'), 'utf-8')
+      .trim()
+      .split('\n');
+    expect(lines).toHaveLength(2);
+  });
+});
+
+describe('migrateAllJournals — 일괄 마이그레이션', () => {
+  it('모든 프로젝트를 순회하며 마이그레이션', async () => {
+    createProject('p1', {
+      id: 'p1',
+      executionState: { journal: [{ type: 'a', timestamp: 1 }] },
+    });
+    createProject('p2', {
+      id: 'p2',
+      executionState: { journal: [{ type: 'b', timestamp: 2 }] },
+    });
+    createProject('p3', { id: 'p3' }); // journal 없음
+
+    const result = await migrateAllJournals();
+    expect(result.totalProjects).toBe(3);
+    expect(result.migratedCount).toBe(2);
+    expect(result.skippedCount).toBe(1);
+    expect(result.failedCount).toBe(0);
+  });
+
+  it('손상된 프로젝트는 graceful skip (failedCount 증가)', async () => {
+    const dir = join(tmpDir, 'corrupt');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'project.json'), '{ invalid json');
+
+    createProject('healthy', {
+      id: 'healthy',
+      executionState: { journal: [{ type: 'a', timestamp: 1 }] },
+    });
+
+    const result = await migrateAllJournals();
+    expect(result.totalProjects).toBe(2);
+    expect(result.migratedCount).toBe(1);
+    expect(result.failedCount).toBe(1);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].projectId).toBe('corrupt');
+  });
+
+  it('dry-run 일괄 모드', async () => {
+    createProject('p1', {
+      id: 'p1',
+      executionState: { journal: [{ type: 'a', timestamp: 1 }] },
+    });
+
+    const result = await migrateAllJournals({ dryRun: true });
+    expect(result.migratedCount).toBe(1);
+    expect(result.dryRun).toBe(true);
+    expect(existsSync(join(tmpDir, 'p1', 'journal.jsonl'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

오케스트레이션 일반화 마이그레이션 작업 **C-1** (단계 1): 기존 프로젝트의
`executionState.journal[]`을 `journal.jsonl`로 일괄 이전하는 도구.

## 추가된 모듈

`scripts/lib/project/journal-migration.js`

- `migrateProjectJournal(projectId, { dryRun })` — 단일 프로젝트 이전
- `migrateAllJournals({ dryRun })` — 전체 프로젝트 일괄 처리

### 안전장치

- **이미 jsonl이 있으면 skip** — 덮어쓰기 방지
- **손상된 entry**는 skip하고 valid만 이전 + `skippedCount` 보고
- **project.json 손상 시** graceful skip + `failures` 배열에 기록 (전체 작업 중단 안 함)
- **dry-run 모드**로 사전 시뮬레이션 가능 (파일 변경 0)

## CLI 사용

```bash
# 사전 시뮬레이션
node scripts/cli.js migrate-journal --dry-run

# 실제 마이그레이션
node scripts/cli.js migrate-journal
```

결과 JSON:
```json
{
  "totalProjects": 12,
  "migratedCount": 8,
  "skippedCount": 3,
  "failedCount": 1,
  "failures": [{ "projectId": "corrupt-id", "error": "..." }],
  "dryRun": false
}
```

## Test plan

- [x] `tests/journal-migration.test.js` 9건 (단일/일괄, dry-run, 손상 처리, skip 케이스)
- [x] 전체 2644 통과 (+9), 회귀 0
- [x] `npm run lint` 통과

## 후속 단계

- **C-2**: 사용처(`pr-manager`, `report-generator`, `execution-utils`, `quality-evaluator`)가 `readJournalEntries(projectId)` 사용하도록 변경
- **C-3**: `recordToJournal`이 in-memory state.journal 동시에 jsonl에도 자동 sync
- **C-4**: project.json의 `executionState.journal` 필드 완전 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)