### PR TITLE
feat(project-manager): journal jsonl hydration + write delta sync (마이그레이션 C-2)

### DIFF
--- a/scripts/lib/project/project-manager.js
+++ b/scripts/lib/project/project-manager.js
@@ -12,6 +12,7 @@ import { projectsDir } from '../core/app-paths.js';
 import { config } from '../core/config.js';
 import { truncateLines } from '../core/text-utils.js';
 import { withFileLock } from '../core/file-lock.js';
+import { readJournalEntries, appendJournalEntry } from './journal.js';
 
 const DEFAULT_BASE_DIR = projectsDir();
 
@@ -87,23 +88,68 @@ function getProjectFilePath(projectId) {
 }
 
 /**
- * 프로젝트 파일을 디스크에서 읽는다.
+ * jsonl이 있으면 우선 사용, 없으면 project.json의 journal[] 그대로 (legacy 호환).
+ * 호출자는 in-memory state.journal을 그대로 사용 가능 → 사용처 영향 0.
+ */
+async function hydrateJournal(projectId, project) {
+  if (!project) return project;
+  const jsonlEntries = await readJournalEntries(projectId);
+  if (jsonlEntries.length === 0) return project; // legacy: project.json journal[] 유지
+  if (!project.executionState) project.executionState = {};
+  project.executionState.journal = jsonlEntries;
+  return project;
+}
+
+/**
+ * state.journal의 새 entry를 jsonl에 append (delta only).
+ * 마이그레이션 안 한 프로젝트의 첫 write에서는 journal[] 전체가 jsonl로 이전됨.
+ *
+ * state-machine entries는 type 대신 action 필드를 사용하므로 자동 정규화.
+ */
+async function syncJournalToJsonl(projectId, project) {
+  const journal = project?.executionState?.journal;
+  if (!Array.isArray(journal) || journal.length === 0) return;
+  const existing = await readJournalEntries(projectId);
+  const newEntries = journal.slice(existing.length);
+  for (const entry of newEntries) {
+    if (!entry || typeof entry !== 'object') continue;
+    const normalized =
+      typeof entry.type === 'string' ? entry : { type: entry.action || 'unknown', ...entry };
+    await appendJournalEntry(projectId, normalized);
+  }
+}
+
+/** project.json에 저장하기 전 journal 필드 제거 — jsonl이 source of truth. */
+function stripJournalForPersistence(project) {
+  if (!project?.executionState?.journal) return project;
+  return {
+    ...project,
+    executionState: { ...project.executionState, journal: undefined },
+  };
+}
+
+/**
+ * 프로젝트 파일을 디스크에서 읽는다 (jsonl hydration 포함).
  * @param {string} projectId - 프로젝트 ID
  * @returns {Promise<object|null>} 프로젝트 또는 null (파일 없음)
  */
 async function readProjectFile(projectId) {
-  return readJsonFile(getProjectFilePath(projectId));
+  const project = await readJsonFile(getProjectFilePath(projectId));
+  if (!project) return null;
+  return hydrateJournal(projectId, project);
 }
 
 /**
- * 프로젝트 객체를 디스크에 기록한다.
+ * 프로젝트 객체를 디스크에 기록한다 (journal jsonl sync + journal 필드 strip).
  * @param {string} projectId - 프로젝트 ID
  * @param {object} project - 프로젝트 객체
  */
 async function writeProjectFile(projectId, project) {
   const dir = getProjectDir(projectId);
   await ensureDir(dir);
-  await writeFile(getProjectFilePath(projectId), JSON.stringify(project, null, 2), 'utf-8');
+  await syncJournalToJsonl(projectId, project);
+  const stripped = stripJournalForPersistence(project);
+  await writeFile(getProjectFilePath(projectId), JSON.stringify(stripped, null, 2), 'utf-8');
 }
 
 /**

--- a/tests/project-manager-journal.test.js
+++ b/tests/project-manager-journal.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  setBaseDir,
+  getProject,
+  createProject,
+  updateProjectStatus,
+} from '../scripts/lib/project/project-manager.js';
+import { setJournalBaseDir } from '../scripts/lib/project/journal.js';
+
+let tmpDir;
+
+function writeRawProject(id, projectData) {
+  const dir = join(tmpDir, id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'project.json'), JSON.stringify(projectData, null, 2));
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'gvc-pm-journal-'));
+  setBaseDir(tmpDir);
+  setJournalBaseDir(tmpDir);
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('getProject — journal hydration', () => {
+  it('jsonl이 있으면 state.journal에 복원된다', async () => {
+    writeRawProject('proj-jsonl', { id: 'proj-jsonl', executionState: {} });
+    const jsonlPath = join(tmpDir, 'proj-jsonl', 'journal.jsonl');
+    writeFileSync(
+      jsonlPath,
+      [
+        JSON.stringify({ type: 'phase-start', phase: 1, timestamp: 1000 }),
+        JSON.stringify({ type: 'task-complete', taskId: 'a', timestamp: 1100 }),
+      ].join('\n') + '\n',
+    );
+
+    const project = await getProject('proj-jsonl');
+    expect(project.executionState.journal).toHaveLength(2);
+    expect(project.executionState.journal[0].type).toBe('phase-start');
+    expect(project.executionState.journal[1].type).toBe('task-complete');
+  });
+
+  it('jsonl 없고 project.json에 journal[] 있으면 그것 그대로 사용 (legacy)', async () => {
+    writeRawProject('proj-legacy', {
+      id: 'proj-legacy',
+      executionState: {
+        journal: [{ type: 'old-entry', timestamp: 5000 }],
+      },
+    });
+
+    const project = await getProject('proj-legacy');
+    expect(project.executionState.journal).toHaveLength(1);
+    expect(project.executionState.journal[0].type).toBe('old-entry');
+  });
+
+  it('jsonl이 우선 — project.json에 journal[] 있어도 jsonl 사용', async () => {
+    writeRawProject('proj-both', {
+      id: 'proj-both',
+      executionState: {
+        journal: [{ type: 'stale-from-json', timestamp: 1 }],
+      },
+    });
+    const jsonlPath = join(tmpDir, 'proj-both', 'journal.jsonl');
+    writeFileSync(jsonlPath, JSON.stringify({ type: 'fresh-from-jsonl', timestamp: 2 }) + '\n');
+
+    const project = await getProject('proj-both');
+    expect(project.executionState.journal).toHaveLength(1);
+    expect(project.executionState.journal[0].type).toBe('fresh-from-jsonl');
+  });
+
+  it('executionState 자체가 없으면 hydration이 executionState를 만들지 않는다', async () => {
+    writeRawProject('proj-no-state', { id: 'proj-no-state' });
+    const project = await getProject('proj-no-state');
+    // jsonl 없으니 executionState는 없는 채로 유지
+    expect(project.executionState).toBeUndefined();
+  });
+
+  it('jsonl 있으면 executionState 자동 생성', async () => {
+    writeRawProject('proj-auto-state', { id: 'proj-auto-state' });
+    const jsonlPath = join(tmpDir, 'proj-auto-state', 'journal.jsonl');
+    writeFileSync(jsonlPath, JSON.stringify({ type: 'a', timestamp: 1 }) + '\n');
+
+    const project = await getProject('proj-auto-state');
+    expect(project.executionState).toBeDefined();
+    expect(project.executionState.journal).toHaveLength(1);
+  });
+});
+
+describe('write — journal jsonl sync + project.json strip', () => {
+  it('createProject는 journal 필드 없이 project.json 저장', async () => {
+    const project = await createProject('test', 'web-app', '설명');
+    const raw = JSON.parse(readFileSync(join(tmpDir, project.id, 'project.json'), 'utf-8'));
+    // 새 프로젝트는 executionState 없으니 journal도 없음
+    expect(raw.executionState?.journal).toBeUndefined();
+  });
+
+  it('updateProjectStatus 후 jsonl sync 동작 (legacy → 자동 이전)', async () => {
+    // 마이그레이션 안 한 프로젝트 시뮬레이션
+    writeRawProject('legacy', {
+      id: 'legacy',
+      name: 'Legacy',
+      type: 'web-app',
+      description: '',
+      mode: 'plan-only',
+      status: 'planning',
+      modifyHistory: [],
+      team: [],
+      discussion: { rounds: [], planDocument: '' },
+      tasks: [],
+      report: null,
+      feedback: [],
+      pullRequests: [],
+      executionState: {
+        journal: [
+          { type: 'old-1', timestamp: 1 },
+          { type: 'old-2', timestamp: 2 },
+        ],
+      },
+    });
+
+    // 어떤 write라도 발생하면 jsonl sync + strip
+    await updateProjectStatus('legacy', 'approved');
+
+    // jsonl에 2 entries 적힘
+    const jsonlPath = join(tmpDir, 'legacy', 'journal.jsonl');
+    expect(existsSync(jsonlPath)).toBe(true);
+    const lines = readFileSync(jsonlPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+
+    // project.json엔 journal 필드 빠짐
+    const raw = JSON.parse(readFileSync(join(tmpDir, 'legacy', 'project.json'), 'utf-8'));
+    expect(raw.executionState?.journal).toBeUndefined();
+  });
+
+  it('연속 write 시 delta만 append (중복 방지)', async () => {
+    writeRawProject('delta', {
+      id: 'delta',
+      name: 'Delta',
+      type: 'web-app',
+      description: '',
+      mode: 'plan-only',
+      status: 'planning',
+      modifyHistory: [],
+      team: [],
+      discussion: { rounds: [], planDocument: '' },
+      tasks: [],
+      report: null,
+      feedback: [],
+      pullRequests: [],
+      executionState: { journal: [{ type: 'a', timestamp: 1 }] },
+    });
+
+    await updateProjectStatus('delta', 'approved');
+
+    const jsonlPath = join(tmpDir, 'delta', 'journal.jsonl');
+    let lines = readFileSync(jsonlPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+
+    // 두 번째 status update — journal 변경 없음
+    // updateProjectStatus가 read → mutate → write이므로
+    // hydration된 journal(jsonl 1개)가 다시 mutate 함수에 들어가고
+    // delta sync는 0이어야 (이미 1개 있고 length 동일)
+    const allowedNext = (current) => (current === 'approved' ? 'planning' : 'approved');
+    void allowedNext;
+    // 'approved' → 'planning' 전이 허용
+    await updateProjectStatus('delta', 'planning');
+
+    lines = readFileSync(jsonlPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1); // 중복 append 안 됨
+  });
+});


### PR DESCRIPTION
## Summary

오케스트레이션 일반화 마이그레이션 작업 **C-2**: `project-manager`의 read/write가
`journal.jsonl`을 source of truth로 사용. **사용처 코드 변경 0** —
in-memory `state.journal`에 자동 hydration.

## 변경

### read 경로 — `readProjectFile`이 jsonl hydration

```js
async function readProjectFile(projectId) {
  const project = await readJsonFile(getProjectFilePath(projectId));
  if (!project) return null;
  return hydrateJournal(projectId, project); // jsonl → state.journal
}
```

- jsonl 있으면 그것 우선 (마이그레이션 한 프로젝트)
- jsonl 없으면 project.json `journal[]` 그대로 (legacy 호환)

### write 경로 — `writeProjectFile`이 delta sync + journal strip

```js
async function writeProjectFile(projectId, project) {
  await ensureDir(dir);
  await syncJournalToJsonl(projectId, project); // 새 entry만 jsonl에 append
  const stripped = stripJournalForPersistence(project);
  await writeFile(..., JSON.stringify(stripped, null, 2));
}
```

- 마이그레이션 안 한 프로젝트의 첫 write에서 `journal[]` 전체가 jsonl로 자동 이전
- project.json엔 `journal` 필드 strip — 비대 해소
- state-machine entries(`type` 없이 `action` 사용)는 자동 정규화

## 사용처 영향

`pr-manager`, `report-generator`, `execution-utils`, `quality-evaluator`가
`state.journal`을 in-memory로 사용 중인데 — hydration이 read에서 자동으로 채워주므로
**코드 변경 0**, 동작 동일.

## Test plan

- [x] `tests/project-manager-journal.test.js` 8건 (hydration, legacy, jsonl 우선, delta sync, strip, executionState 자동 생성)
- [x] 전체 2652 통과 (+8), 회귀 0 — 51개 기존 state-machine 테스트, execution-loop 테스트 모두 그대로 통과
- [x] `npm run lint` 통과

## 후속 단계

- **C-3**: `recordToJournal` 영속화는 이미 `withProjectLock` 단위로 sync되므로 추가 작업 불필요
- **C-4**: legacy `project.json journal[]` 필드는 다음 write에서 자동으로 strip됨 — 일괄 정리 PR 또는 한 사이클 운영 후 자연스러운 제거 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)