### PR TITLE
feat(agent): 다차원 학습 신호 추출 모듈 (자가발전 #2)

### DIFF
--- a/scripts/lib/agent/agent-performance.js
+++ b/scripts/lib/agent/agent-performance.js
@@ -1,0 +1,160 @@
+/**
+ * agent-performance — 에이전트 자가발전을 위한 다차원 학습 신호 추출
+ *
+ * 기존 extractAgentPerformance는 critical/important 이슈 카운트만 본다.
+ * 자가발전(self-evolution) 루프가 더 균형 잡힌 결정을 하려면 비용·시간·재시도·
+ * 에스컬레이션 신호도 함께 봐야 한다. 이 모듈은 6개 신호를 독립 함수로 추출하고
+ * 가중치 기반 통합 점수를 계산한다.
+ *
+ * - quality      : critical*3 + important. 낮을수록 좋음.
+ * - time         : phase-completion 사이 누적 ms. 낮을수록 좋음.
+ * - cost         : 프로젝트 누적 USD. 낮을수록 좋음.
+ * - retry        : Phase별 fix 시도 합계. 낮을수록 좋음.
+ * - escalation   : escalating state 진입 횟수. 낮을수록 좋음.
+ * - contribution : 유니크 이슈 / 전체 이슈. 높을수록 좋음 (중복 리뷰어 패널티).
+ *
+ * computeAggregateScore는 페널티 신호를 음수로, 기여 신호를 양수로 합산한다.
+ * 절대값 자체는 의미 없고 비교 용도(shadow vs active 등)로 쓰인다.
+ */
+
+/**
+ * @typedef {Object} AgentSignals
+ * @property {number} quality
+ * @property {number} time
+ * @property {number} cost
+ * @property {number} retry
+ * @property {number} escalation
+ * @property {number} contribution
+ */
+
+export const DEFAULT_SIGNAL_WEIGHTS = Object.freeze({
+  quality: 1.0,
+  time: 0.001, // ms 단위 → 초당 0.001 페널티
+  cost: 1.0, // USD 직접
+  retry: 0.5,
+  escalation: 2.0,
+  contribution: 5.0,
+});
+
+/**
+ * 리뷰 이슈에서 quality 신호 추출 (critical*3 + important).
+ * @param {{ issues?: Array<{ severity?: string }> }} performance
+ * @returns {number}
+ */
+export function extractQualitySignal(performance) {
+  const issues = performance?.issues || [];
+  let critical = 0;
+  let important = 0;
+  for (const i of issues) {
+    if (i?.severity === 'critical') critical++;
+    else if (i?.severity === 'important') important++;
+  }
+  return critical * 3 + important;
+}
+
+/**
+ * journal에서 phase-completion 이벤트 사이의 누적 ms를 시간 신호로 추출.
+ * 이벤트가 2개 미만이면 0.
+ * @param {object} project
+ * @returns {number}
+ */
+export function extractTimeSignal(project) {
+  const journal = project?.executionState?.journal || [];
+  const completions = journal.filter((e) => e?.type === 'phase-completion' && e.timestamp);
+  if (completions.length < 2) return 0;
+  const first = completions[0].timestamp;
+  const last = completions[completions.length - 1].timestamp;
+  return Math.max(0, last - first);
+}
+
+/**
+ * 프로젝트 누적 비용 신호 (cost-tracker가 project.metrics에 기록한 값 사용).
+ * 누적값이 없으면 0.
+ * @param {object} project
+ * @returns {number}
+ */
+export function extractCostSignal(project) {
+  const cost = project?.metrics?.totalCost;
+  return typeof cost === 'number' && cost >= 0 ? cost : 0;
+}
+
+/**
+ * journal의 phase-completion entry에서 fixAttempts 합계를 retry 신호로 추출.
+ * @param {object} project
+ * @returns {number}
+ */
+export function extractRetrySignal(project) {
+  const journal = project?.executionState?.journal || [];
+  let total = 0;
+  for (const entry of journal) {
+    if (entry?.type === 'phase-completion' && typeof entry.fixAttempts === 'number') {
+      total += entry.fixAttempts;
+    }
+  }
+  return total;
+}
+
+/**
+ * graph-transition 이벤트 중 toState === 'escalating' 횟수를 에스컬레이션 신호로 추출.
+ * 'escalating' state는 fix 2회 실패 시 진입한다.
+ * @param {object} project
+ * @returns {number}
+ */
+export function extractEscalationSignal(project) {
+  const journal = project?.executionState?.journal || [];
+  let count = 0;
+  for (const entry of journal) {
+    if (entry?.type === 'graph-transition' && entry.toState === 'escalating') count++;
+  }
+  return count;
+}
+
+/**
+ * 유니크 이슈 description / 전체 이슈 비율을 기여도 신호로 추출.
+ * 이슈가 0개면 0 (기여 측정 불가).
+ * @param {{ reviews?: Array<{ issues?: Array<{ description?: string }> }> }} performance
+ * @returns {number}
+ */
+export function extractContributionSignal(performance) {
+  const reviews = performance?.reviews || [];
+  const allIssues = reviews.flatMap((r) => r?.issues || []);
+  if (allIssues.length === 0) return 0;
+  const unique = new Set(allIssues.map((i) => (i?.description || '').trim()).filter(Boolean));
+  return unique.size / allIssues.length;
+}
+
+/**
+ * 6개 신호를 한 번에 추출한다.
+ * @param {object} project
+ * @param {object} performance - extractAgentPerformance의 단일 항목
+ * @returns {AgentSignals}
+ */
+export function extractAllSignals(project, performance) {
+  return {
+    quality: extractQualitySignal(performance),
+    time: extractTimeSignal(project),
+    cost: extractCostSignal(project),
+    retry: extractRetrySignal(project),
+    escalation: extractEscalationSignal(project),
+    contribution: extractContributionSignal(performance),
+  };
+}
+
+/**
+ * 가중치 기반 통합 점수. 페널티 신호는 음수, 기여 신호는 양수로 합산.
+ * 두 후보 비교(shadow vs active 등)에서 더 높은 점수가 우수.
+ * @param {AgentSignals} signals
+ * @param {Partial<AgentSignals>} [weights] - DEFAULT_SIGNAL_WEIGHTS와 병합
+ * @returns {number}
+ */
+export function computeAggregateScore(signals, weights = DEFAULT_SIGNAL_WEIGHTS) {
+  const w = { ...DEFAULT_SIGNAL_WEIGHTS, ...weights };
+  return (
+    -signals.quality * w.quality -
+    signals.time * w.time -
+    signals.cost * w.cost -
+    signals.retry * w.retry -
+    signals.escalation * w.escalation +
+    signals.contribution * w.contribution
+  );
+}

--- a/tests/agent-performance.test.js
+++ b/tests/agent-performance.test.js
@@ -1,0 +1,244 @@
+/**
+ * agent-performance — 6개 학습 신호 추출 + 가중치 통합 점수 단위 테스트
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  extractQualitySignal,
+  extractTimeSignal,
+  extractCostSignal,
+  extractRetrySignal,
+  extractEscalationSignal,
+  extractContributionSignal,
+  extractAllSignals,
+  computeAggregateScore,
+  DEFAULT_SIGNAL_WEIGHTS,
+} from '../scripts/lib/agent/agent-performance.js';
+
+describe('extractQualitySignal', () => {
+  it('critical 1개당 3점, important 1개당 1점을 누적한다', () => {
+    const performance = {
+      issues: [
+        { severity: 'critical' },
+        { severity: 'critical' },
+        { severity: 'important' },
+        { severity: 'minor' }, // 무시
+      ],
+    };
+    expect(extractQualitySignal(performance)).toBe(3 * 2 + 1);
+  });
+
+  it('이슈가 없으면 0', () => {
+    expect(extractQualitySignal({})).toBe(0);
+    expect(extractQualitySignal({ issues: [] })).toBe(0);
+    expect(extractQualitySignal(null)).toBe(0);
+  });
+
+  it('severity 누락 이슈는 무시한다', () => {
+    expect(extractQualitySignal({ issues: [{ description: 'x' }] })).toBe(0);
+  });
+});
+
+describe('extractTimeSignal', () => {
+  it('phase-completion 이벤트 첫/마지막 timestamp 차이를 ms로 반환', () => {
+    const project = {
+      executionState: {
+        journal: [
+          { type: 'phase-completion', timestamp: 1000 },
+          { type: 'agent-call', timestamp: 1500 },
+          { type: 'phase-completion', timestamp: 5000 },
+        ],
+      },
+    };
+    expect(extractTimeSignal(project)).toBe(4000);
+  });
+
+  it('phase-completion이 2개 미만이면 0', () => {
+    expect(extractTimeSignal({})).toBe(0);
+    expect(
+      extractTimeSignal({
+        executionState: { journal: [{ type: 'phase-completion', timestamp: 100 }] },
+      }),
+    ).toBe(0);
+  });
+
+  it('timestamp 없는 entry는 무시', () => {
+    const project = {
+      executionState: {
+        journal: [{ type: 'phase-completion' }, { type: 'phase-completion', timestamp: 2000 }],
+      },
+    };
+    expect(extractTimeSignal(project)).toBe(0);
+  });
+});
+
+describe('extractCostSignal', () => {
+  it('project.metrics.totalCost를 그대로 반환', () => {
+    expect(extractCostSignal({ metrics: { totalCost: 1.23 } })).toBe(1.23);
+  });
+
+  it('값 없으면 0', () => {
+    expect(extractCostSignal({})).toBe(0);
+    expect(extractCostSignal(null)).toBe(0);
+  });
+
+  it('음수 값은 0으로 정규화', () => {
+    expect(extractCostSignal({ metrics: { totalCost: -1 } })).toBe(0);
+  });
+
+  it('비-숫자 값은 0', () => {
+    expect(extractCostSignal({ metrics: { totalCost: '5' } })).toBe(0);
+  });
+});
+
+describe('extractRetrySignal', () => {
+  it('phase-completion entry의 fixAttempts 합계', () => {
+    const project = {
+      executionState: {
+        journal: [
+          { type: 'phase-completion', fixAttempts: 1 },
+          { type: 'phase-completion', fixAttempts: 0 },
+          { type: 'phase-completion', fixAttempts: 2 },
+          { type: 'agent-call', fixAttempts: 99 }, // 무시
+        ],
+      },
+    };
+    expect(extractRetrySignal(project)).toBe(3);
+  });
+
+  it('journal 없으면 0', () => {
+    expect(extractRetrySignal({})).toBe(0);
+  });
+});
+
+describe('extractEscalationSignal', () => {
+  it("graph-transition 중 toState === 'escalating' 횟수", () => {
+    const project = {
+      executionState: {
+        journal: [
+          { type: 'graph-transition', toState: 'fixing' },
+          { type: 'graph-transition', toState: 'escalating' },
+          { type: 'graph-transition', toState: 'escalating' },
+          { type: 'graph-transition', toState: 'reviewing' },
+        ],
+      },
+    };
+    expect(extractEscalationSignal(project)).toBe(2);
+  });
+
+  it('escalating 진입이 없으면 0', () => {
+    expect(extractEscalationSignal({})).toBe(0);
+  });
+});
+
+describe('extractContributionSignal', () => {
+  it('유니크 이슈 description / 전체 이슈 비율', () => {
+    const performance = {
+      reviews: [
+        { issues: [{ description: 'XSS' }, { description: 'SQL injection' }] },
+        { issues: [{ description: 'XSS' }] }, // 중복
+      ],
+    };
+    expect(extractContributionSignal(performance)).toBeCloseTo(2 / 3);
+  });
+
+  it('이슈가 없으면 0', () => {
+    expect(extractContributionSignal({})).toBe(0);
+    expect(extractContributionSignal({ reviews: [{ issues: [] }] })).toBe(0);
+  });
+
+  it('빈 description은 유니크에서 제외', () => {
+    const performance = {
+      reviews: [{ issues: [{ description: '' }, { description: 'real' }] }],
+    };
+    // unique = {'real'} (1개), allIssues = 2개 → 0.5
+    expect(extractContributionSignal(performance)).toBe(0.5);
+  });
+});
+
+describe('extractAllSignals', () => {
+  it('6개 신호를 한 번에 추출한다', () => {
+    const project = {
+      metrics: { totalCost: 0.5 },
+      executionState: {
+        journal: [
+          { type: 'phase-completion', timestamp: 1000, fixAttempts: 1 },
+          { type: 'phase-completion', timestamp: 3000, fixAttempts: 0 },
+          { type: 'graph-transition', toState: 'escalating' },
+        ],
+      },
+    };
+    const performance = {
+      issues: [{ severity: 'critical' }, { severity: 'important' }],
+      reviews: [{ issues: [{ description: 'XSS' }] }],
+    };
+    const signals = extractAllSignals(project, performance);
+
+    expect(signals).toEqual({
+      quality: 4,
+      time: 2000,
+      cost: 0.5,
+      retry: 1,
+      escalation: 1,
+      contribution: 1,
+    });
+  });
+});
+
+describe('computeAggregateScore', () => {
+  it('페널티 신호는 음수로, 기여는 양수로 합산', () => {
+    const signals = {
+      quality: 4,
+      time: 2000,
+      cost: 0.5,
+      retry: 1,
+      escalation: 1,
+      contribution: 1,
+    };
+    const score = computeAggregateScore(signals);
+    // -4*1 - 2000*0.001 - 0.5*1 - 1*0.5 - 1*2 + 1*5
+    //  = -4 - 2 - 0.5 - 0.5 - 2 + 5 = -4
+    expect(score).toBeCloseTo(-4);
+  });
+
+  it('가중치 override가 적용된다', () => {
+    const signals = {
+      quality: 1,
+      time: 0,
+      cost: 0,
+      retry: 0,
+      escalation: 0,
+      contribution: 0,
+    };
+    const score = computeAggregateScore(signals, { quality: 10 });
+    expect(score).toBe(-10);
+  });
+
+  it('동일 신호에서는 점수 동일', () => {
+    const a = extractAllSignals({}, {});
+    const b = extractAllSignals({}, {});
+    expect(computeAggregateScore(a)).toBe(computeAggregateScore(b));
+  });
+
+  it('quality가 더 낮은(좋은) 후보가 더 높은 점수를 받는다 (shadow 비교 시나리오)', () => {
+    const baseline = { quality: 5, time: 0, cost: 0, retry: 0, escalation: 0, contribution: 0 };
+    const candidate = { quality: 2, time: 0, cost: 0, retry: 0, escalation: 0, contribution: 0 };
+    expect(computeAggregateScore(candidate)).toBeGreaterThan(computeAggregateScore(baseline));
+  });
+});
+
+describe('DEFAULT_SIGNAL_WEIGHTS', () => {
+  it('frozen 객체로 외부 변경을 차단한다', () => {
+    expect(Object.isFrozen(DEFAULT_SIGNAL_WEIGHTS)).toBe(true);
+  });
+
+  it('6개 신호 모두 가중치가 정의되어 있다', () => {
+    expect(DEFAULT_SIGNAL_WEIGHTS).toMatchObject({
+      quality: expect.any(Number),
+      time: expect.any(Number),
+      cost: expect.any(Number),
+      retry: expect.any(Number),
+      escalation: expect.any(Number),
+      contribution: expect.any(Number),
+    });
+  });
+});


### PR DESCRIPTION
## Summary

자가발전 루프가 critical/important 카운트만 보던 한계를 해소합니다. 신규 \`agent-performance.js\` 모듈은 6개 신호를 독립 함수로 추출하고 가중치 기반 통합 점수를 제공합니다.

### 6개 신호

| 신호 | 추출 출처 | 방향 |
|---|---|---|
| quality | review issues (critical*3 + important) | 낮을수록 좋음 |
| time | journal phase-completion 사이 ms | 낮을수록 좋음 |
| cost | project.metrics.totalCost (cost-tracker) | 낮을수록 좋음 |
| retry | phase-completion entry의 fixAttempts 합계 | 낮을수록 좋음 |
| escalation | graph-transition toState='escalating' 횟수 | 낮을수록 좋음 |
| contribution | 유니크 issue / 전체 issue 비율 | 높을수록 좋음 |

### computeAggregateScore

페널티 신호는 음수, 기여 신호는 양수로 합산. 두 후보 비교(shadow vs active)에 사용. 절대값 자체는 의미 없음 — 비교용.

### 다음 단계 (별도 PR)

- **#3 Provenance**: agent-overrides 마크다운에 origin 메타데이터 frontmatter 추가, signal 필드에 이 모듈 결과 사용
- **#1 Shadow mode + auto-rollback**: candidate override를 N개 프로젝트 동안 평행 평가, computeAggregateScore로 promote/discard 결정

## Test plan

- [x] 24개 단위 테스트 그린
- [x] 전체 회귀: 134 files, 2946 pass / 2 skip
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)