### PR TITLE
feat(agent): provenance 메타데이터 모듈 (자가발전 #3)

### DIFF
--- a/scripts/lib/agent/agent-provenance.js
+++ b/scripts/lib/agent/agent-provenance.js
@@ -1,0 +1,209 @@
+/**
+ * agent-provenance — agent-overrides의 origin/추적성 메타데이터
+ *
+ * 자가발전 시스템에서 각 override 항목이 "어느 프로젝트, 어느 시점, 어떤 신호에 의해 추가됐는지"를
+ * 추적해야 잘못된 학습을 디버깅·revert할 수 있다. 외부 의존성 0 원칙을 지키기 위해 마크다운에
+ * YAML/JSON frontmatter를 끼우지 않고 **별도 JSON 파일**로 분리한다.
+ *
+ * 파일 레이아웃:
+ *   ~/.claude/good-vibe/agent-overrides/{roleId}.md              ← 사람 읽는 가이드 (변경 없음)
+ *   ~/.claude/good-vibe/agent-overrides/{roleId}.provenance.json ← 메타데이터 (이 모듈)
+ *
+ * provenance.json 없거나 손상되면 graceful 처리 (override 자체는 정상 동작).
+ */
+
+import { readFile, writeFile, unlink } from 'fs/promises';
+import { resolve } from 'path';
+import { randomBytes } from 'crypto';
+import { ensureDir, fileExists } from '../core/file-writer.js';
+import { agentOverridesDir } from '../core/app-paths.js';
+import { inputError } from '../core/validators.js';
+
+const VALID_ROLE_PATTERN = /^[a-z][a-z0-9-]{0,49}$/;
+const VALID_SOURCES = Object.freeze(['project-feedback', 'cross-project-pattern', 'manual']);
+
+let overridesDir = agentOverridesDir();
+
+/**
+ * 테스트용 — overrides 디렉토리 변경.
+ * @param {string} dir
+ */
+export function setProvenanceDir(dir) {
+  overridesDir = dir;
+}
+
+function validateRoleId(roleId) {
+  if (typeof roleId !== 'string' || !VALID_ROLE_PATTERN.test(roleId)) {
+    throw inputError(`유효하지 않은 roleId: ${roleId}`);
+  }
+}
+
+function provenancePath(roleId) {
+  return resolve(overridesDir, `${roleId}.provenance.json`);
+}
+
+function generateEntryId() {
+  return `ent-${randomBytes(6).toString('hex')}`;
+}
+
+/**
+ * @typedef {Object} ProvenanceSignals
+ * @property {number} [quality]
+ * @property {number} [time]
+ * @property {number} [cost]
+ * @property {number} [retry]
+ * @property {number} [escalation]
+ * @property {number} [contribution]
+ */
+
+/**
+ * @typedef {Object} ProvenanceEntry
+ * @property {string} id - "ent-{12hex}"
+ * @property {string} source - 'project-feedback' | 'cross-project-pattern' | 'manual'
+ * @property {string} timestamp - ISO 8601
+ * @property {string} [summary] - 사람이 읽을 한 줄 요약
+ * @property {string} [projectId] - source=project-feedback일 때
+ * @property {string[]} [projectIds] - source=cross-project-pattern일 때
+ * @property {string} [pattern] - source=cross-project-pattern일 때
+ * @property {number} [repeatCount] - source=cross-project-pattern일 때
+ * @property {ProvenanceSignals} [signals] - agent-performance.extractAllSignals 결과
+ */
+
+/**
+ * @typedef {Object} ProvenanceFile
+ * @property {string} roleId
+ * @property {string} revision - 마지막 갱신 시점의 플러그인 버전
+ * @property {string} lastUpdated - ISO 8601
+ * @property {ProvenanceEntry[]} entries
+ */
+
+/**
+ * provenance entry를 검증한다. 기본 필드와 source별 필수 필드를 확인.
+ * @param {Partial<ProvenanceEntry>} entry
+ * @returns {ProvenanceEntry} 검증/정규화된 entry (id, timestamp 자동 보강)
+ */
+export function validateProvenanceEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    throw inputError('provenance entry는 object여야 합니다');
+  }
+  if (!VALID_SOURCES.includes(entry.source)) {
+    throw inputError(`유효하지 않은 source: ${entry.source} (허용: ${VALID_SOURCES.join(', ')})`);
+  }
+  if (entry.source === 'project-feedback' && typeof entry.projectId !== 'string') {
+    throw inputError("source='project-feedback'은 projectId(string)가 필요합니다");
+  }
+  if (entry.source === 'cross-project-pattern') {
+    if (!Array.isArray(entry.projectIds) || entry.projectIds.length < 1) {
+      throw inputError("source='cross-project-pattern'은 projectIds(배열)이 필요합니다");
+    }
+    if (typeof entry.pattern !== 'string' || !entry.pattern) {
+      throw inputError("source='cross-project-pattern'은 pattern(string)이 필요합니다");
+    }
+  }
+  return {
+    ...entry,
+    id: entry.id || generateEntryId(),
+    timestamp: entry.timestamp || new Date().toISOString(),
+  };
+}
+
+/**
+ * provenance 파일을 읽는다. 파일이 없거나 손상되면 빈 구조 반환.
+ * @param {string} roleId
+ * @returns {Promise<ProvenanceFile>}
+ */
+export async function loadProvenance(roleId) {
+  validateRoleId(roleId);
+  const path = provenancePath(roleId);
+  if (!(await fileExists(path))) {
+    return { roleId, revision: '', lastUpdated: '', entries: [] };
+  }
+  try {
+    const raw = await readFile(path, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return { roleId, revision: '', lastUpdated: '', entries: [] };
+    }
+    return {
+      roleId: parsed.roleId || roleId,
+      revision: parsed.revision || '',
+      lastUpdated: parsed.lastUpdated || '',
+      entries: Array.isArray(parsed.entries) ? parsed.entries : [],
+    };
+  } catch {
+    // 손상된 JSON은 빈 구조로 graceful — override 자체 동작은 보존
+    return { roleId, revision: '', lastUpdated: '', entries: [] };
+  }
+}
+
+/**
+ * provenance 파일 전체를 덮어쓴다.
+ * @param {ProvenanceFile} file
+ */
+export async function saveProvenance(file) {
+  if (!file || typeof file !== 'object') {
+    throw inputError('saveProvenance: file 객체가 필요합니다');
+  }
+  validateRoleId(file.roleId);
+  await ensureDir(overridesDir);
+  const path = provenancePath(file.roleId);
+  const payload = {
+    roleId: file.roleId,
+    revision: file.revision || '',
+    lastUpdated: file.lastUpdated || new Date().toISOString(),
+    entries: Array.isArray(file.entries) ? file.entries : [],
+  };
+  await writeFile(path, JSON.stringify(payload, null, 2), 'utf-8');
+}
+
+/**
+ * provenance entry를 추가한다 (기존 파일에 append).
+ * id, timestamp 자동 보강. lastUpdated 갱신.
+ * @param {string} roleId
+ * @param {Partial<ProvenanceEntry>} entry
+ * @param {{ revision?: string }} [options]
+ * @returns {Promise<ProvenanceEntry>} 저장된 entry (정규화 포함)
+ */
+export async function appendProvenanceEntry(roleId, entry, options = {}) {
+  const validated = validateProvenanceEntry(entry);
+  const file = await loadProvenance(roleId);
+  file.entries.push(validated);
+  file.lastUpdated = new Date().toISOString();
+  if (options.revision) file.revision = options.revision;
+  await saveProvenance(file);
+  return validated;
+}
+
+/**
+ * 특정 entry를 id로 제거한다 (CEO revert 시나리오).
+ * @param {string} roleId
+ * @param {string} entryId
+ * @returns {Promise<{ removed: boolean, remaining: number }>}
+ */
+export async function removeProvenanceEntry(roleId, entryId) {
+  if (typeof entryId !== 'string' || !entryId) {
+    throw inputError('entryId가 필요합니다');
+  }
+  const file = await loadProvenance(roleId);
+  const before = file.entries.length;
+  file.entries = file.entries.filter((e) => e.id !== entryId);
+  const removed = file.entries.length < before;
+  if (removed) {
+    file.lastUpdated = new Date().toISOString();
+    await saveProvenance(file);
+  }
+  return { removed, remaining: file.entries.length };
+}
+
+/**
+ * provenance 파일을 삭제한다 (override 자체는 보존).
+ * @param {string} roleId
+ * @returns {Promise<{ deleted: boolean }>}
+ */
+export async function clearProvenance(roleId) {
+  validateRoleId(roleId);
+  const path = provenancePath(roleId);
+  if (!(await fileExists(path))) return { deleted: false };
+  await unlink(path);
+  return { deleted: true };
+}

--- a/tests/agent-provenance.test.js
+++ b/tests/agent-provenance.test.js
@@ -1,0 +1,263 @@
+/**
+ * agent-provenance — origin 메타데이터 CRUD 단위 테스트
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile, readFile } from 'fs/promises';
+import { resolve } from 'path';
+import {
+  setProvenanceDir,
+  validateProvenanceEntry,
+  loadProvenance,
+  saveProvenance,
+  appendProvenanceEntry,
+  removeProvenanceEntry,
+  clearProvenance,
+} from '../scripts/lib/agent/agent-provenance.js';
+
+const TMP_DIR = resolve('.tmp-test-agent-provenance');
+
+beforeEach(async () => {
+  await mkdir(TMP_DIR, { recursive: true });
+  setProvenanceDir(TMP_DIR);
+});
+
+afterEach(async () => {
+  await rm(TMP_DIR, { recursive: true, force: true });
+});
+
+function provenancePath(roleId) {
+  return resolve(TMP_DIR, `${roleId}.provenance.json`);
+}
+
+describe('validateProvenanceEntry', () => {
+  it("source='project-feedback'에 projectId 필수", () => {
+    expect(() => validateProvenanceEntry({ source: 'project-feedback' })).toThrow('projectId');
+  });
+
+  it("source='cross-project-pattern'에 projectIds + pattern 필수", () => {
+    expect(() =>
+      validateProvenanceEntry({ source: 'cross-project-pattern', projectIds: [] }),
+    ).toThrow('projectIds');
+    expect(() =>
+      validateProvenanceEntry({
+        source: 'cross-project-pattern',
+        projectIds: ['p-1'],
+      }),
+    ).toThrow('pattern');
+  });
+
+  it("source='manual'은 추가 필드 없이도 통과", () => {
+    const result = validateProvenanceEntry({ source: 'manual', summary: 'CEO 직접 추가' });
+    expect(result.source).toBe('manual');
+    expect(result.id).toMatch(/^ent-[a-f0-9]{12}$/);
+    expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('알 수 없는 source 거부', () => {
+    expect(() => validateProvenanceEntry({ source: 'unknown' })).toThrow('유효하지 않은 source');
+  });
+
+  it('id/timestamp가 명시되면 그대로 사용', () => {
+    const result = validateProvenanceEntry({
+      source: 'manual',
+      id: 'ent-fixed-id',
+      timestamp: '2026-04-01T00:00:00Z',
+    });
+    expect(result.id).toBe('ent-fixed-id');
+    expect(result.timestamp).toBe('2026-04-01T00:00:00Z');
+  });
+});
+
+describe('loadProvenance', () => {
+  it('파일 없으면 빈 entries 반환', async () => {
+    const file = await loadProvenance('cto');
+    expect(file).toEqual({ roleId: 'cto', revision: '', lastUpdated: '', entries: [] });
+  });
+
+  it('정상 파일을 그대로 읽는다', async () => {
+    const data = {
+      roleId: 'cto',
+      revision: '2.0.0-rc.1',
+      lastUpdated: '2026-04-27T10:00:00Z',
+      entries: [
+        {
+          id: 'ent-001',
+          source: 'manual',
+          timestamp: '2026-04-27T10:00:00Z',
+          summary: '초기 추가',
+        },
+      ],
+    };
+    await writeFile(provenancePath('cto'), JSON.stringify(data), 'utf-8');
+
+    const file = await loadProvenance('cto');
+    expect(file.roleId).toBe('cto');
+    expect(file.revision).toBe('2.0.0-rc.1');
+    expect(file.entries).toHaveLength(1);
+    expect(file.entries[0].source).toBe('manual');
+  });
+
+  it('손상된 JSON은 빈 구조로 graceful', async () => {
+    await writeFile(provenancePath('cto'), '{ this is not json', 'utf-8');
+    const file = await loadProvenance('cto');
+    expect(file.entries).toEqual([]);
+  });
+
+  it('잘못된 roleId 거부', async () => {
+    await expect(loadProvenance('../../../etc/passwd')).rejects.toThrow('유효하지 않은 roleId');
+  });
+});
+
+describe('saveProvenance', () => {
+  it('전체 파일을 덮어쓴다', async () => {
+    await saveProvenance({
+      roleId: 'qa',
+      revision: 'r1',
+      lastUpdated: '2026-04-01T00:00:00Z',
+      entries: [
+        {
+          id: 'ent-x',
+          source: 'manual',
+          timestamp: '2026-04-01T00:00:00Z',
+        },
+      ],
+    });
+
+    const raw = await readFile(provenancePath('qa'), 'utf-8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.roleId).toBe('qa');
+    expect(parsed.entries).toHaveLength(1);
+  });
+
+  it('lastUpdated가 비어있으면 자동 채움', async () => {
+    await saveProvenance({ roleId: 'qa', entries: [] });
+    const file = await loadProvenance('qa');
+    expect(file.lastUpdated).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe('appendProvenanceEntry', () => {
+  it('첫 entry 추가 시 파일 생성', async () => {
+    const saved = await appendProvenanceEntry(
+      'cto',
+      {
+        source: 'project-feedback',
+        projectId: 'weather-bot-2025-12-abc',
+        signals: { quality: 4, time: 2000, cost: 0.5, retry: 1, escalation: 1, contribution: 1 },
+        summary: 'TDD 강제 추가',
+      },
+      { revision: '2.0.0-rc.1' },
+    );
+
+    expect(saved.id).toMatch(/^ent-[a-f0-9]{12}$/);
+    expect(saved.signals.quality).toBe(4);
+
+    const file = await loadProvenance('cto');
+    expect(file.revision).toBe('2.0.0-rc.1');
+    expect(file.entries).toHaveLength(1);
+    expect(file.entries[0].id).toBe(saved.id);
+  });
+
+  it('기존 entries 보존하며 append', async () => {
+    await appendProvenanceEntry('cto', {
+      source: 'manual',
+      summary: 'first',
+    });
+    await appendProvenanceEntry('cto', {
+      source: 'manual',
+      summary: 'second',
+    });
+
+    const file = await loadProvenance('cto');
+    expect(file.entries).toHaveLength(2);
+    expect(file.entries[0].summary).toBe('first');
+    expect(file.entries[1].summary).toBe('second');
+  });
+
+  it('signals 필드를 그대로 보존 (agent-performance 통합 지점)', async () => {
+    const signals = {
+      quality: 0,
+      time: 5000,
+      cost: 0.12,
+      retry: 0,
+      escalation: 0,
+      contribution: 1,
+    };
+    await appendProvenanceEntry('qa', {
+      source: 'project-feedback',
+      projectId: 'p-1',
+      signals,
+    });
+
+    const file = await loadProvenance('qa');
+    expect(file.entries[0].signals).toEqual(signals);
+  });
+
+  it('cross-project-pattern entry 추가', async () => {
+    await appendProvenanceEntry('qa', {
+      source: 'cross-project-pattern',
+      projectIds: ['p-1', 'p-2', 'p-3'],
+      pattern: 'edge-case-coverage',
+      repeatCount: 3,
+    });
+
+    const file = await loadProvenance('qa');
+    expect(file.entries[0].source).toBe('cross-project-pattern');
+    expect(file.entries[0].projectIds).toEqual(['p-1', 'p-2', 'p-3']);
+    expect(file.entries[0].pattern).toBe('edge-case-coverage');
+  });
+});
+
+describe('removeProvenanceEntry', () => {
+  it('id로 entry 제거', async () => {
+    const a = await appendProvenanceEntry('cto', { source: 'manual', summary: 'a' });
+    const b = await appendProvenanceEntry('cto', { source: 'manual', summary: 'b' });
+
+    const result = await removeProvenanceEntry('cto', a.id);
+    expect(result).toEqual({ removed: true, remaining: 1 });
+
+    const file = await loadProvenance('cto');
+    expect(file.entries).toHaveLength(1);
+    expect(file.entries[0].id).toBe(b.id);
+  });
+
+  it('존재하지 않는 id는 removed=false', async () => {
+    await appendProvenanceEntry('cto', { source: 'manual' });
+    const result = await removeProvenanceEntry('cto', 'ent-nonexistent');
+    expect(result.removed).toBe(false);
+  });
+
+  it('빈 entryId 거부', async () => {
+    await expect(removeProvenanceEntry('cto', '')).rejects.toThrow('entryId');
+  });
+});
+
+describe('clearProvenance', () => {
+  it('파일 삭제', async () => {
+    await appendProvenanceEntry('cto', { source: 'manual' });
+    const result = await clearProvenance('cto');
+    expect(result.deleted).toBe(true);
+
+    const file = await loadProvenance('cto');
+    expect(file.entries).toEqual([]);
+  });
+
+  it('파일이 없으면 deleted=false', async () => {
+    const result = await clearProvenance('cto');
+    expect(result.deleted).toBe(false);
+  });
+});
+
+describe('persistence — 마크다운 override와 독립', () => {
+  it('provenance.json만 손상돼도 override.md는 영향 없음', async () => {
+    await writeFile(resolve(TMP_DIR, 'cto.md'), '# CTO Override', 'utf-8');
+    await writeFile(provenancePath('cto'), 'CORRUPTED', 'utf-8');
+
+    const file = await loadProvenance('cto');
+    expect(file.entries).toEqual([]); // graceful
+
+    // override.md는 그대로
+    const md = await readFile(resolve(TMP_DIR, 'cto.md'), 'utf-8');
+    expect(md).toBe('# CTO Override');
+  });
+});


### PR DESCRIPTION
## Summary

각 agent-override 항목이 어느 프로젝트·시점·신호에서 학습됐는지 추적해 잘못된 학습을 디버깅·revert 할 수 있게 합니다. 외부 의존성 0 원칙을 위해 frontmatter 대신 **별도 JSON 파일**.

### 파일 레이아웃

\`\`\`
~/.claude/good-vibe/agent-overrides/
├── cto.md                  ← 사람 읽는 가이드 (변경 없음)
└── cto.provenance.json     ← origin 메타데이터 (신규)
\`\`\`

### API

- \`loadProvenance(roleId)\` — 파일 없거나 손상돼도 빈 구조 반환 (graceful)
- \`saveProvenance(file)\` — 전체 덮어쓰기
- \`appendProvenanceEntry(roleId, entry, { revision })\` — id/timestamp 자동 보강
- \`removeProvenanceEntry(roleId, entryId)\` — CEO revert 시나리오
- \`clearProvenance(roleId)\` — 메타만 삭제 (override.md 보존)
- \`validateProvenanceEntry(entry)\` — source별 필수 필드 검증

### Entry 스키마

source별 분기:
- \`project-feedback\` → projectId 필수
- \`cross-project-pattern\` → projectIds + pattern 필수
- \`manual\` → CEO 직접 추가

\`signals\` 필드는 PR #273 \`agent-performance.extractAllSignals\` 결과를 그대로 보존 → 다음 PR(shadow mode)의 비교 기준이 됨.

### 다음 PR (#1 Shadow mode)

- candidate override를 N개 프로젝트 동안 평행 평가
- 각 프로젝트 종료 시 \`appendProvenanceEntry\`로 signal 누적
- N 도달 시 \`computeAggregateScore\` 비교 → promote/discard/rollback

## Test plan

- [x] 21개 단위 테스트 그린 (validate / load / save / append / remove / clear / 손상 graceful)
- [x] 전체 회귀: 135 files, 2967 pass / 2 skip
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)