### PR TITLE
feat(agent): shadow mode + auto-rollback (자가발전 #1)

### DIFF
--- a/scripts/lib/agent/agent-shadow-mode.js
+++ b/scripts/lib/agent/agent-shadow-mode.js
@@ -1,0 +1,388 @@
+/**
+ * agent-shadow-mode — 자가발전 학습안의 회귀 안전망
+ *
+ * 새 override 제안을 즉시 active로 적용하면 잘못된 학습이 다음 프로젝트들을 더 나쁘게 만들어도
+ * CEO가 발견할 때까지 계속 누적된다. 이 모듈은 학습안을 candidate로 격리하고 N개 프로젝트
+ * 동안 신호를 누적한 뒤, 통합 점수 비교로 promote/discard를 결정한다.
+ *
+ * 파일 레이아웃 (사용자 레벨, agent-overrides 디렉토리):
+ *   {roleId}.md                       ← active (실제 사용)
+ *   {roleId}.candidate.md             ← shadow 후보 (이 모듈)
+ *   {roleId}.provenance.json          ← active provenance (agent-provenance 모듈)
+ *   {roleId}.candidate.provenance.json ← candidate provenance + 누적 시그널 (이 모듈)
+ *
+ * 의사결정 — evaluateCandidate(roleId, { minProjects, weights }):
+ *   1. candidate가 없거나 projectCount < minProjects → 'pending'
+ *   2. candidate 누적 시그널의 통합 점수 vs active 누적 시그널 비교
+ *   3. candidate 점수 > active 점수 → 'promote'
+ *   4. candidate 점수 ≤ active 점수 → 'discard'
+ *
+ * 실제 dry-run 실행(execution loop 통합)은 후속 PR. 이 모듈은 데이터 구조 + 의사결정 로직만.
+ */
+
+import { readFile, writeFile, unlink } from 'fs/promises';
+import { resolve } from 'path';
+import { ensureDir, fileExists } from '../core/file-writer.js';
+import { agentOverridesDir } from '../core/app-paths.js';
+import { inputError } from '../core/validators.js';
+import {
+  loadProvenance,
+  saveProvenance,
+  appendProvenanceEntry,
+  validateProvenanceEntry,
+} from './agent-provenance.js';
+import { computeAggregateScore, DEFAULT_SIGNAL_WEIGHTS } from './agent-performance.js';
+
+const VALID_ROLE_PATTERN = /^[a-z][a-z0-9-]{0,49}$/;
+export const DEFAULT_MIN_SHADOW_PROJECTS = 3;
+
+let overridesDir = agentOverridesDir();
+
+/**
+ * 테스트용 — overrides 디렉토리 변경.
+ * @param {string} dir
+ */
+export function setShadowDir(dir) {
+  overridesDir = dir;
+}
+
+function validateRoleId(roleId) {
+  if (typeof roleId !== 'string' || !VALID_ROLE_PATTERN.test(roleId)) {
+    throw inputError(`유효하지 않은 roleId: ${roleId}`);
+  }
+}
+
+function activePath(roleId) {
+  return resolve(overridesDir, `${roleId}.md`);
+}
+
+function candidatePath(roleId) {
+  return resolve(overridesDir, `${roleId}.candidate.md`);
+}
+
+/**
+ * candidate provenance 파일 경로. agent-provenance 모듈은 active만 다루므로
+ * 여기서는 candidate 전용 경로를 분리해 직접 읽고 쓴다.
+ */
+function candidateProvenancePath(roleId) {
+  return resolve(overridesDir, `${roleId}.candidate.provenance.json`);
+}
+
+/**
+ * candidate override를 저장한다 (active는 건드리지 않음).
+ * 동시에 candidate provenance에 origin entry를 추가한다.
+ * @param {string} roleId
+ * @param {string} content - 마크다운 내용
+ * @param {Partial<import('./agent-provenance.js').ProvenanceEntry>} originEntry
+ * @returns {Promise<{ candidatePath: string, entryId: string }>}
+ */
+export async function saveCandidateOverride(roleId, content, originEntry) {
+  validateRoleId(roleId);
+  if (typeof content !== 'string') {
+    throw inputError('candidate content는 string이어야 합니다');
+  }
+  const validatedEntry = validateProvenanceEntry(originEntry);
+  await ensureDir(overridesDir);
+  await writeFile(candidatePath(roleId), content, 'utf-8');
+
+  const file = await loadCandidateProvenance(roleId);
+  file.entries.push(validatedEntry);
+  file.lastUpdated = new Date().toISOString();
+  await saveCandidateProvenance(file);
+
+  return { candidatePath: candidatePath(roleId), entryId: validatedEntry.id };
+}
+
+/**
+ * candidate override 마크다운을 로드한다.
+ * @param {string} roleId
+ * @returns {Promise<string|null>}
+ */
+export async function loadCandidateOverride(roleId) {
+  validateRoleId(roleId);
+  const path = candidatePath(roleId);
+  if (!(await fileExists(path))) return null;
+  return readFile(path, 'utf-8');
+}
+
+/**
+ * candidate provenance 파일을 읽는다 (없거나 손상되면 빈 구조).
+ * projectResults 필드는 N개 프로젝트의 평가 신호 누적용 (이 모듈 전용).
+ * @param {string} roleId
+ * @returns {Promise<{ roleId: string, lastUpdated: string, entries: Array, projectResults: Array<{ projectId: string, signals: object, timestamp: string }> }>}
+ */
+export async function loadCandidateProvenance(roleId) {
+  validateRoleId(roleId);
+  const path = candidateProvenancePath(roleId);
+  if (!(await fileExists(path))) {
+    return { roleId, lastUpdated: '', entries: [], projectResults: [] };
+  }
+  try {
+    const raw = await readFile(path, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return { roleId, lastUpdated: '', entries: [], projectResults: [] };
+    }
+    return {
+      roleId: parsed.roleId || roleId,
+      lastUpdated: parsed.lastUpdated || '',
+      entries: Array.isArray(parsed.entries) ? parsed.entries : [],
+      projectResults: Array.isArray(parsed.projectResults) ? parsed.projectResults : [],
+    };
+  } catch {
+    return { roleId, lastUpdated: '', entries: [], projectResults: [] };
+  }
+}
+
+/**
+ * candidate provenance 전체 덮어쓰기.
+ */
+async function saveCandidateProvenance(file) {
+  validateRoleId(file.roleId);
+  await ensureDir(overridesDir);
+  const payload = {
+    roleId: file.roleId,
+    lastUpdated: file.lastUpdated || new Date().toISOString(),
+    entries: file.entries || [],
+    projectResults: file.projectResults || [],
+  };
+  await writeFile(candidateProvenancePath(file.roleId), JSON.stringify(payload, null, 2), 'utf-8');
+}
+
+/**
+ * candidate (또는 active)의 한 프로젝트 평가 신호를 누적한다.
+ * which='candidate' (기본): candidate.provenance.json의 projectResults에 추가.
+ * which='active': active provenance에 'project-feedback' entry로 추가 (signals 보존).
+ *
+ * @param {string} roleId
+ * @param {string} projectId
+ * @param {import('./agent-performance.js').AgentSignals} signals
+ * @param {{ which?: 'candidate' | 'active' }} [options]
+ */
+export async function recordProjectResult(roleId, projectId, signals, options = {}) {
+  if (typeof projectId !== 'string' || !projectId) {
+    throw inputError('projectId가 필요합니다');
+  }
+  if (!signals || typeof signals !== 'object') {
+    throw inputError('signals가 필요합니다');
+  }
+  const which = options.which || 'candidate';
+  const timestamp = new Date().toISOString();
+
+  if (which === 'candidate') {
+    const file = await loadCandidateProvenance(roleId);
+    file.projectResults.push({ projectId, signals, timestamp });
+    file.lastUpdated = timestamp;
+    await saveCandidateProvenance(file);
+  } else if (which === 'active') {
+    await appendProvenanceEntry(roleId, {
+      source: 'project-feedback',
+      projectId,
+      signals,
+      summary: `active 누적 (${projectId})`,
+    });
+  } else {
+    throw inputError(`유효하지 않은 which: ${which}`);
+  }
+}
+
+/**
+ * candidate에 누적된 N개 프로젝트의 평균 신호를 계산한다.
+ * @param {Array<{ signals: object }>} results
+ * @returns {import('./agent-performance.js').AgentSignals|null} 평균. 결과 없으면 null.
+ */
+export function averageSignals(results) {
+  if (!Array.isArray(results) || results.length === 0) return null;
+  const sum = { quality: 0, time: 0, cost: 0, retry: 0, escalation: 0, contribution: 0 };
+  for (const r of results) {
+    const s = r?.signals || {};
+    sum.quality += Number(s.quality) || 0;
+    sum.time += Number(s.time) || 0;
+    sum.cost += Number(s.cost) || 0;
+    sum.retry += Number(s.retry) || 0;
+    sum.escalation += Number(s.escalation) || 0;
+    sum.contribution += Number(s.contribution) || 0;
+  }
+  const n = results.length;
+  return {
+    quality: sum.quality / n,
+    time: sum.time / n,
+    cost: sum.cost / n,
+    retry: sum.retry / n,
+    escalation: sum.escalation / n,
+    contribution: sum.contribution / n,
+  };
+}
+
+/**
+ * active provenance의 'project-feedback' entry에서 signals를 추출해 평균을 낸다.
+ * baseline 비교용.
+ * @param {string} roleId
+ * @returns {Promise<import('./agent-performance.js').AgentSignals|null>}
+ */
+async function loadActiveAverageSignals(roleId) {
+  const file = await loadProvenance(roleId);
+  const projectResults = (file.entries || [])
+    .filter((e) => e?.source === 'project-feedback' && e?.signals)
+    .map((e) => ({ signals: e.signals }));
+  return averageSignals(projectResults);
+}
+
+/**
+ * candidate를 평가한다.
+ *
+ * @param {string} roleId
+ * @param {{ minProjects?: number, weights?: object }} [options]
+ * @returns {Promise<{
+ *   decision: 'promote' | 'discard' | 'pending',
+ *   reason: string,
+ *   projectCount: number,
+ *   activeScore: number | null,
+ *   candidateScore: number | null,
+ *   activeSignals: object | null,
+ *   candidateSignals: object | null,
+ * }>}
+ */
+export async function evaluateCandidate(roleId, options = {}) {
+  validateRoleId(roleId);
+  const minProjects = options.minProjects ?? DEFAULT_MIN_SHADOW_PROJECTS;
+  const weights = options.weights || DEFAULT_SIGNAL_WEIGHTS;
+
+  const candidate = await loadCandidateProvenance(roleId);
+  const projectCount = candidate.projectResults.length;
+
+  if (projectCount < minProjects) {
+    return {
+      decision: 'pending',
+      reason: `candidate 누적 ${projectCount} / 최소 ${minProjects} 프로젝트 필요`,
+      projectCount,
+      activeScore: null,
+      candidateScore: null,
+      activeSignals: null,
+      candidateSignals: null,
+    };
+  }
+
+  const candidateSignals = averageSignals(candidate.projectResults);
+  const activeSignals = await loadActiveAverageSignals(roleId);
+
+  const candidateScore = candidateSignals ? computeAggregateScore(candidateSignals, weights) : null;
+  const activeScore = activeSignals ? computeAggregateScore(activeSignals, weights) : null;
+
+  // active baseline이 없으면 (첫 학습) candidate를 그대로 promote
+  if (activeScore === null) {
+    return {
+      decision: 'promote',
+      reason: 'active baseline 없음 — candidate를 첫 학습으로 promote',
+      projectCount,
+      activeScore: null,
+      candidateScore,
+      activeSignals: null,
+      candidateSignals,
+    };
+  }
+
+  if (candidateScore > activeScore) {
+    return {
+      decision: 'promote',
+      reason: `candidate 점수 ${candidateScore.toFixed(3)} > active ${activeScore.toFixed(3)}`,
+      projectCount,
+      activeScore,
+      candidateScore,
+      activeSignals,
+      candidateSignals,
+    };
+  }
+  return {
+    decision: 'discard',
+    reason: `candidate 점수 ${candidateScore.toFixed(3)} ≤ active ${activeScore.toFixed(3)}`,
+    projectCount,
+    activeScore,
+    candidateScore,
+    activeSignals,
+    candidateSignals,
+  };
+}
+
+/**
+ * candidate를 active로 승격한다 (candidate.md → active.md).
+ * candidate provenance entries는 active provenance에 머지하고, candidate 파일들은 삭제.
+ * @param {string} roleId
+ * @returns {Promise<{ promoted: boolean, mergedEntries: number }>}
+ */
+export async function promoteCandidate(roleId) {
+  validateRoleId(roleId);
+  const candContent = await loadCandidateOverride(roleId);
+  if (candContent === null) return { promoted: false, mergedEntries: 0 };
+
+  // candidate.md → active.md
+  await ensureDir(overridesDir);
+  await writeFile(activePath(roleId), candContent, 'utf-8');
+
+  // candidate provenance entries (origin) → active provenance에 머지
+  const candidateProv = await loadCandidateProvenance(roleId);
+  const activeProv = await loadProvenance(roleId);
+  for (const entry of candidateProv.entries) {
+    activeProv.entries.push(entry);
+  }
+  // candidate.projectResults → active provenance에 project-feedback entries로 이전
+  // 이렇게 해야 다음 candidate 평가 시 active baseline 평균에 포함된다.
+  for (const result of candidateProv.projectResults) {
+    activeProv.entries.push(
+      validateProvenanceEntry({
+        source: 'project-feedback',
+        projectId: result.projectId,
+        timestamp: result.timestamp,
+        signals: result.signals,
+        summary: 'inherited from candidate (promoted)',
+      }),
+    );
+  }
+  activeProv.lastUpdated = new Date().toISOString();
+  await saveProvenance(activeProv);
+
+  // candidate 파일들 삭제
+  await unlinkIfExists(candidatePath(roleId));
+  await unlinkIfExists(candidateProvenancePath(roleId));
+
+  return { promoted: true, mergedEntries: candidateProv.entries.length };
+}
+
+/**
+ * candidate를 폐기한다 (active 영향 없음).
+ * @param {string} roleId
+ * @returns {Promise<{ discarded: boolean }>}
+ */
+export async function discardCandidate(roleId) {
+  validateRoleId(roleId);
+  const existed = await fileExists(candidatePath(roleId));
+  await unlinkIfExists(candidatePath(roleId));
+  await unlinkIfExists(candidateProvenancePath(roleId));
+  return { discarded: existed };
+}
+
+/**
+ * candidate 상태를 조회한다 (디버깅/UI용).
+ * @param {string} roleId
+ * @returns {Promise<{ exists: boolean, projectCount: number, projectIds: string[], entryCount: number }>}
+ */
+export async function getCandidateState(roleId) {
+  validateRoleId(roleId);
+  const exists = await fileExists(candidatePath(roleId));
+  if (!exists) {
+    return { exists: false, projectCount: 0, projectIds: [], entryCount: 0 };
+  }
+  const prov = await loadCandidateProvenance(roleId);
+  return {
+    exists: true,
+    projectCount: prov.projectResults.length,
+    projectIds: prov.projectResults.map((r) => r.projectId),
+    entryCount: prov.entries.length,
+  };
+}
+
+async function unlinkIfExists(path) {
+  if (await fileExists(path)) {
+    await unlink(path);
+  }
+}

--- a/tests/agent-shadow-mode.test.js
+++ b/tests/agent-shadow-mode.test.js
@@ -1,0 +1,343 @@
+/**
+ * agent-shadow-mode — candidate 격리 + 누적 평가 + promote/discard 단위 테스트
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile, readFile } from 'fs/promises';
+import { resolve } from 'path';
+import {
+  setShadowDir,
+  saveCandidateOverride,
+  loadCandidateOverride,
+  loadCandidateProvenance,
+  recordProjectResult,
+  averageSignals,
+  evaluateCandidate,
+  promoteCandidate,
+  discardCandidate,
+  getCandidateState,
+  DEFAULT_MIN_SHADOW_PROJECTS,
+} from '../scripts/lib/agent/agent-shadow-mode.js';
+import { setProvenanceDir, loadProvenance } from '../scripts/lib/agent/agent-provenance.js';
+
+const TMP_DIR = resolve('.tmp-test-agent-shadow-mode');
+
+beforeEach(async () => {
+  await mkdir(TMP_DIR, { recursive: true });
+  setShadowDir(TMP_DIR);
+  setProvenanceDir(TMP_DIR);
+});
+
+afterEach(async () => {
+  await rm(TMP_DIR, { recursive: true, force: true });
+});
+
+const SAMPLE_ORIGIN = {
+  source: 'project-feedback',
+  projectId: 'p-init',
+  summary: 'TDD 강제 추가',
+};
+
+function fixtureSignals(overrides = {}) {
+  return {
+    quality: 4,
+    time: 2000,
+    cost: 0.5,
+    retry: 1,
+    escalation: 0,
+    contribution: 0.8,
+    ...overrides,
+  };
+}
+
+describe('saveCandidateOverride / loadCandidateOverride', () => {
+  it('candidate.md 파일을 저장하고 그대로 읽는다', async () => {
+    const content = '# CTO Candidate\n\n- TDD 강제';
+    await saveCandidateOverride('cto', content, SAMPLE_ORIGIN);
+
+    const loaded = await loadCandidateOverride('cto');
+    expect(loaded).toBe(content);
+  });
+
+  it('active.md는 영향 없음 (격리)', async () => {
+    await writeFile(resolve(TMP_DIR, 'cto.md'), '# CTO ACTIVE', 'utf-8');
+    await saveCandidateOverride('cto', '# CTO CANDIDATE', SAMPLE_ORIGIN);
+
+    const active = await readFile(resolve(TMP_DIR, 'cto.md'), 'utf-8');
+    expect(active).toBe('# CTO ACTIVE');
+
+    const candidate = await loadCandidateOverride('cto');
+    expect(candidate).toBe('# CTO CANDIDATE');
+  });
+
+  it('저장과 동시에 candidate provenance에 origin entry 추가', async () => {
+    await saveCandidateOverride('cto', '# x', SAMPLE_ORIGIN);
+    const prov = await loadCandidateProvenance('cto');
+    expect(prov.entries).toHaveLength(1);
+    expect(prov.entries[0].source).toBe('project-feedback');
+    expect(prov.entries[0].projectId).toBe('p-init');
+  });
+
+  it('content가 string이 아니면 거부', async () => {
+    await expect(saveCandidateOverride('cto', null, SAMPLE_ORIGIN)).rejects.toThrow('string');
+  });
+
+  it('candidate 없으면 loadCandidateOverride는 null', async () => {
+    const result = await loadCandidateOverride('cto');
+    expect(result).toBeNull();
+  });
+});
+
+describe('recordProjectResult', () => {
+  it("which='candidate' (기본)은 projectResults에 누적", async () => {
+    await saveCandidateOverride('cto', '# x', SAMPLE_ORIGIN);
+    await recordProjectResult('cto', 'p-1', fixtureSignals());
+    await recordProjectResult('cto', 'p-2', fixtureSignals({ quality: 2 }));
+
+    const prov = await loadCandidateProvenance('cto');
+    expect(prov.projectResults).toHaveLength(2);
+    expect(prov.projectResults[0].projectId).toBe('p-1');
+    expect(prov.projectResults[1].projectId).toBe('p-2');
+    expect(prov.projectResults[1].signals.quality).toBe(2);
+  });
+
+  it("which='active'는 active provenance에 'project-feedback' entry로 추가", async () => {
+    await recordProjectResult('cto', 'p-active-1', fixtureSignals(), { which: 'active' });
+    const active = await loadProvenance('cto');
+    expect(active.entries).toHaveLength(1);
+    expect(active.entries[0].source).toBe('project-feedback');
+    expect(active.entries[0].signals.quality).toBe(4);
+  });
+
+  it('projectId 빈 값 거부', async () => {
+    await expect(recordProjectResult('cto', '', fixtureSignals())).rejects.toThrow('projectId');
+  });
+
+  it('signals 누락 거부', async () => {
+    await expect(recordProjectResult('cto', 'p-1', null)).rejects.toThrow('signals');
+  });
+});
+
+describe('averageSignals', () => {
+  it('빈 배열은 null', () => {
+    expect(averageSignals([])).toBeNull();
+    expect(averageSignals(null)).toBeNull();
+  });
+
+  it('6개 신호 평균 계산', () => {
+    const results = [
+      {
+        signals: { quality: 4, time: 2000, cost: 0.5, retry: 1, escalation: 0, contribution: 0.8 },
+      },
+      {
+        signals: { quality: 2, time: 1000, cost: 0.3, retry: 0, escalation: 1, contribution: 0.6 },
+      },
+    ];
+    expect(averageSignals(results)).toEqual({
+      quality: 3,
+      time: 1500,
+      cost: 0.4,
+      retry: 0.5,
+      escalation: 0.5,
+      contribution: 0.7,
+    });
+  });
+
+  it('일부 필드 누락 시 0으로 대체', () => {
+    const result = averageSignals([{ signals: {} }, { signals: { quality: 4 } }]);
+    expect(result.quality).toBe(2);
+    expect(result.time).toBe(0);
+  });
+});
+
+describe('evaluateCandidate', () => {
+  it('candidate가 없으면 pending', async () => {
+    const result = await evaluateCandidate('cto');
+    expect(result.decision).toBe('pending');
+    expect(result.projectCount).toBe(0);
+  });
+
+  it(`projectCount < minProjects (기본 ${DEFAULT_MIN_SHADOW_PROJECTS})면 pending`, async () => {
+    await saveCandidateOverride('cto', '# x', SAMPLE_ORIGIN);
+    await recordProjectResult('cto', 'p-1', fixtureSignals());
+
+    const result = await evaluateCandidate('cto');
+    expect(result.decision).toBe('pending');
+    expect(result.projectCount).toBe(1);
+    expect(result.reason).toContain('1 / 최소 3');
+  });
+
+  it('active baseline 없고 candidate 누적 충분 → promote', async () => {
+    await saveCandidateOverride('cto', '# x', SAMPLE_ORIGIN);
+    for (let i = 1; i <= 3; i++) {
+      await recordProjectResult('cto', `p-${i}`, fixtureSignals());
+    }
+
+    const result = await evaluateCandidate('cto');
+    expect(result.decision).toBe('promote');
+    expect(result.activeScore).toBeNull();
+    expect(result.candidateScore).not.toBeNull();
+  });
+
+  it('candidate가 active보다 우수하면 promote', async () => {
+    // active baseline: quality 5 (나쁨)
+    for (let i = 1; i <= 3; i++) {
+      await recordProjectResult('cto', `active-p-${i}`, fixtureSignals({ quality: 5 }), {
+        which: 'active',
+      });
+    }
+    // candidate: quality 1 (좋음)
+    await saveCandidateOverride('cto', '# x', SAMPLE_ORIGIN);
+    for (let i = 1; i <= 3; i++) {
+      await recordProjectResult('cto', `cand-p-${i}`, fixtureSignals({ quality: 1 }));
+    }
+
+    const result = await evaluateCandidate('cto');
+    expect(result.decision).toBe('promote');
+    expect(result.candidateScore).toBeGreaterThan(result.activeScore);
+  });
+
+  it('candidate가 active보다 열등하면 discard', async () => {
+    // active baseline: quality 1 (좋음)
+    for (let i = 1; i <= 3; i++) {
+      await recordProjectResult('cto', `active-p-${i}`, fixtureSignals({ quality: 1 }), {
+        which: 'active',
+      });
+    }
+    // candidate: quality 5 (나쁨)
+    await saveCandidateOverride('cto', '# x', SAMPLE_ORIGIN);
+    for (let i = 1; i <= 3; i++) {
+      await recordProjectResult('cto', `cand-p-${i}`, fixtureSignals({ quality: 5 }));
+    }
+
+    const result = await evaluateCandidate('cto');
+    expect(result.decision).toBe('discard');
+    expect(result.candidateScore).toBeLessThanOrEqual(result.activeScore);
+  });
+
+  it('minProjects override가 적용된다', async () => {
+    await saveCandidateOverride('cto', '# x', SAMPLE_ORIGIN);
+    await recordProjectResult('cto', 'p-1', fixtureSignals());
+
+    const result = await evaluateCandidate('cto', { minProjects: 1 });
+    expect(result.decision).not.toBe('pending');
+  });
+});
+
+describe('promoteCandidate', () => {
+  it('candidate.md를 active.md로 교체하고 candidate 파일들 삭제', async () => {
+    await writeFile(resolve(TMP_DIR, 'cto.md'), '# OLD ACTIVE', 'utf-8');
+    await saveCandidateOverride('cto', '# NEW ACTIVE', SAMPLE_ORIGIN);
+    await recordProjectResult('cto', 'p-1', fixtureSignals());
+
+    const result = await promoteCandidate('cto');
+    expect(result.promoted).toBe(true);
+
+    const newActive = await readFile(resolve(TMP_DIR, 'cto.md'), 'utf-8');
+    expect(newActive).toBe('# NEW ACTIVE');
+
+    const candidate = await loadCandidateOverride('cto');
+    expect(candidate).toBeNull();
+  });
+
+  it('candidate provenance entries + projectResults를 active로 머지', async () => {
+    await saveCandidateOverride('cto', '# x', SAMPLE_ORIGIN);
+    await recordProjectResult('cto', 'p-1', fixtureSignals());
+
+    await promoteCandidate('cto');
+
+    const active = await loadProvenance('cto');
+    // origin entry 1개 + projectResults가 project-feedback entries로 이전된 1개 → 최소 2개
+    expect(active.entries.length).toBeGreaterThanOrEqual(2);
+    const inherited = active.entries.find(
+      (e) => e.source === 'project-feedback' && (e.summary || '').includes('inherited'),
+    );
+    expect(inherited).toBeDefined();
+    expect(inherited.projectId).toBe('p-1');
+    expect(inherited.signals).toBeDefined();
+  });
+
+  it('candidate 없으면 promoted=false', async () => {
+    const result = await promoteCandidate('cto');
+    expect(result.promoted).toBe(false);
+  });
+});
+
+describe('discardCandidate', () => {
+  it('candidate 파일 삭제 (active 보존)', async () => {
+    await writeFile(resolve(TMP_DIR, 'cto.md'), '# ACTIVE', 'utf-8');
+    await saveCandidateOverride('cto', '# CANDIDATE', SAMPLE_ORIGIN);
+
+    const result = await discardCandidate('cto');
+    expect(result.discarded).toBe(true);
+
+    expect(await loadCandidateOverride('cto')).toBeNull();
+    const active = await readFile(resolve(TMP_DIR, 'cto.md'), 'utf-8');
+    expect(active).toBe('# ACTIVE');
+  });
+
+  it('candidate 없으면 discarded=false', async () => {
+    const result = await discardCandidate('cto');
+    expect(result.discarded).toBe(false);
+  });
+});
+
+describe('getCandidateState', () => {
+  it('candidate 없으면 exists=false', async () => {
+    const state = await getCandidateState('cto');
+    expect(state).toEqual({ exists: false, projectCount: 0, projectIds: [], entryCount: 0 });
+  });
+
+  it('candidate 있으면 누적 정보 반환', async () => {
+    await saveCandidateOverride('cto', '# x', SAMPLE_ORIGIN);
+    await recordProjectResult('cto', 'p-1', fixtureSignals());
+    await recordProjectResult('cto', 'p-2', fixtureSignals());
+
+    const state = await getCandidateState('cto');
+    expect(state.exists).toBe(true);
+    expect(state.projectCount).toBe(2);
+    expect(state.projectIds).toEqual(['p-1', 'p-2']);
+    expect(state.entryCount).toBe(1); // origin entry 1개
+  });
+});
+
+describe('end-to-end shadow lifecycle', () => {
+  it('학습 제안 → 3개 프로젝트 dry-run → promote → 다음 학습 제안', async () => {
+    // 1. 초기 active 없음
+    // 2. 학습 제안 1: candidate 저장
+    await saveCandidateOverride('cto', '# v1', {
+      source: 'project-feedback',
+      projectId: 'p-source',
+    });
+
+    // 3. 3개 프로젝트 평가 누적
+    await recordProjectResult('cto', 'p-1', fixtureSignals());
+    await recordProjectResult('cto', 'p-2', fixtureSignals());
+    await recordProjectResult('cto', 'p-3', fixtureSignals());
+
+    // 4. 평가 → promote (active baseline 없음)
+    const eval1 = await evaluateCandidate('cto');
+    expect(eval1.decision).toBe('promote');
+
+    // 5. promote 실행
+    await promoteCandidate('cto');
+    expect(await loadCandidateOverride('cto')).toBeNull();
+
+    // 6. 두 번째 학습 제안: 더 나쁜 후보
+    await saveCandidateOverride('cto', '# v2 worse', {
+      source: 'project-feedback',
+      projectId: 'p-source-2',
+    });
+    await recordProjectResult('cto', 'p-4', fixtureSignals({ quality: 99 }));
+    await recordProjectResult('cto', 'p-5', fixtureSignals({ quality: 99 }));
+    await recordProjectResult('cto', 'p-6', fixtureSignals({ quality: 99 }));
+
+    // 7. 평가 → discard (active baseline이 더 좋음)
+    const eval2 = await evaluateCandidate('cto');
+    expect(eval2.decision).toBe('discard');
+
+    // 8. discard 실행
+    await discardCandidate('cto');
+    const finalActive = await readFile(resolve(TMP_DIR, 'cto.md'), 'utf-8');
+    expect(finalActive).toBe('# v1'); // 원래 promote된 버전 그대로
+  });
+});


### PR DESCRIPTION
## Summary

학습 제안을 즉시 active로 적용하면 잘못된 학습이 다음 프로젝트들을 더 나쁘게 만들어도 CEO가 발견할 때까지 누적됩니다. 이 모듈은 학습안을 candidate로 격리하고 N개 프로젝트 동안 신호를 누적한 뒤, **통합 점수 비교**로 promote/discard를 결정합니다.

### 파일 레이아웃

\`\`\`
~/.claude/good-vibe/agent-overrides/
├── cto.md                            ← active (실제 사용)
├── cto.candidate.md                  ← shadow 후보
├── cto.provenance.json               ← active provenance (PR #274)
└── cto.candidate.provenance.json     ← origin entries + projectResults 누적 (이 PR)
\`\`\`

### 의사결정

\`\`\`
saveCandidateOverride() → candidate.md 저장
   ▼
N개 프로젝트 동안 recordProjectResult() 누적
   ▼
evaluateCandidate(roleId, { minProjects=3 })
   ├─ projectCount < minProjects     → 'pending'
   ├─ active baseline 없음            → 'promote' (첫 학습)
   ├─ candidateScore > activeScore   → 'promote'
   └─ otherwise                       → 'discard'
\`\`\`

\`computeAggregateScore\` (PR #273)로 6개 신호를 가중 합산해 비교.

### promote 시 baseline 보존

\`promoteCandidate()\`는 \`candidate.projectResults\`를 active provenance에 \`project-feedback\` entries로 이전 — 다음 candidate 평가 시 active baseline 평균에 자연스럽게 포함됨. 이 흐름이 e2e 테스트로 검증됨.

### Tier 1 자가발전 3종 완료

| PR | 기능 |
|---|---|
| #273 | 다차원 학습 신호 추출 (#2) |
| #274 | provenance 메타데이터 (#3) |
| **이 PR** | shadow mode + auto-rollback (#1) |

다음 단계는 actual fix-loop 통합 (별도 PR) — \`agent-feedback.autoApplyFeedback\`을 \`saveCandidateOverride\` 경유로 변경, execution-loop에서 \`recordProjectResult\` 자동 호출.

## Test plan

- [x] 26개 단위 테스트 그린 (e2e lifecycle 포함: 학습→3프로젝트→promote→두 번째 학습→discard)
- [x] 전체 회귀: 136 files, 2993 pass / 2 skip
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)