### PR TITLE
feat(agent): autoApplyFeedbackViaShadow — 학습안 shadow 경유 (자가발전 통합 A-1)

### DIFF
--- a/scripts/lib/agent/agent-feedback.js
+++ b/scripts/lib/agent/agent-feedback.js
@@ -11,6 +11,11 @@ import { parseJsonArray } from '../core/json-parser.js';
 import { validateRoleId, assertWithinRoot } from '../core/validators.js';
 import { agentOverridesDir, projectsDir } from '../core/app-paths.js';
 import { buildSectioned, toMarkdownList } from '../core/prompt-builder.js';
+import {
+  saveCandidateOverride,
+  loadCandidateOverride,
+  discardCandidate,
+} from './agent-shadow-mode.js';
 
 const DEFAULT_OVERRIDES_DIR = agentOverridesDir();
 let overridesDir = DEFAULT_OVERRIDES_DIR;
@@ -230,6 +235,47 @@ export async function autoApplyFeedback(feedbackList) {
         await writeFile(filePath, feedback, 'utf-8');
       }),
   );
+}
+
+/**
+ * 피드백 리스트를 shadow mode 경유로 적용한다.
+ *
+ * 기존 autoApplyFeedback은 active override(`{roleId}.md`)에 즉시 덮어써서
+ * 잘못된 학습이 다음 프로젝트들을 더 나쁘게 만들어도 회귀가 어렵다.
+ * 이 함수는 candidate(`{roleId}.candidate.md`)로 격리 저장하고 N개 프로젝트
+ * 동안 평가받게 해, 회귀 안전망(agent-shadow-mode)을 통과한 후에만 promote된다.
+ *
+ * 이전 candidate가 평가 중이었다면 새 제안이 들어올 때 폐기한다 — 최신 학습 제안 우선.
+ *
+ * @param {Array<{roleId: string, feedback: string, origin?: object}>|null} feedbackList
+ * @param {{ defaultOrigin?: object }} [options] - 각 항목에 origin이 없을 때 사용할 기본값
+ * @returns {Promise<Array<{ roleId: string, candidatePath: string, entryId: string, replacedExisting: boolean }>>}
+ */
+export async function autoApplyFeedbackViaShadow(feedbackList, options = {}) {
+  if (!feedbackList || feedbackList.length === 0) return [];
+  const defaultOrigin = options.defaultOrigin || { source: 'manual' };
+
+  const results = [];
+  for (const item of feedbackList) {
+    if (!item || !item.feedback) continue;
+    const { roleId, feedback, origin } = item;
+
+    // 이전 candidate가 남아 있으면 폐기 (최신 제안 우선)
+    const existing = await loadCandidateOverride(roleId);
+    const replacedExisting = existing !== null;
+    if (replacedExisting) {
+      await discardCandidate(roleId);
+    }
+
+    const saved = await saveCandidateOverride(roleId, feedback, origin || defaultOrigin);
+    results.push({
+      roleId,
+      candidatePath: saved.candidatePath,
+      entryId: saved.entryId,
+      replacedExisting,
+    });
+  }
+  return results;
 }
 
 /**

--- a/tests/agent-feedback-auto.test.js
+++ b/tests/agent-feedback-auto.test.js
@@ -3,10 +3,16 @@ import { mkdir, rm, readFile } from 'fs/promises';
 import { resolve } from 'path';
 import {
   autoApplyFeedback,
+  autoApplyFeedbackViaShadow,
   setOverridesDir,
   saveAgentOverride,
   loadAgentOverride,
 } from '../scripts/lib/agent/agent-feedback.js';
+import {
+  setShadowDir,
+  loadCandidateOverride,
+  loadCandidateProvenance,
+} from '../scripts/lib/agent/agent-shadow-mode.js';
 import { fileExists } from '../scripts/lib/core/file-writer.js';
 
 const TMP_DIR = resolve('.tmp-test-agent-feedback-auto');
@@ -14,6 +20,7 @@ const TMP_DIR = resolve('.tmp-test-agent-feedback-auto');
 beforeEach(async () => {
   await mkdir(TMP_DIR, { recursive: true });
   setOverridesDir(TMP_DIR);
+  setShadowDir(TMP_DIR);
 });
 
 afterEach(async () => {
@@ -69,5 +76,97 @@ describe('autoApplyFeedback', () => {
     expect(backendContent).toBeNull();
     const frontendContent = await loadAgentOverride('frontend');
     expect(frontendContent).toContain('유효한 피드백');
+  });
+});
+
+describe('autoApplyFeedbackViaShadow', () => {
+  it('피드백을 candidate로 격리 저장한다 (active.md는 건드리지 않음)', async () => {
+    await saveAgentOverride('backend', '# 기존 active 가이드');
+    const result = await autoApplyFeedbackViaShadow([
+      {
+        roleId: 'backend',
+        feedback: '# 학습안\n- 에러 처리 강화',
+        origin: { source: 'project-feedback', projectId: 'p-1' },
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].roleId).toBe('backend');
+    expect(result[0].entryId).toMatch(/^ent-[a-f0-9]{12}$/);
+
+    // active는 그대로
+    expect(await loadAgentOverride('backend')).toBe('# 기존 active 가이드');
+
+    // candidate에 저장됨
+    const candidate = await loadCandidateOverride('backend');
+    expect(candidate).toContain('에러 처리 강화');
+
+    // candidate provenance에 origin entry 추가
+    const prov = await loadCandidateProvenance('backend');
+    expect(prov.entries).toHaveLength(1);
+    expect(prov.entries[0].source).toBe('project-feedback');
+    expect(prov.entries[0].projectId).toBe('p-1');
+  });
+
+  it('이전 candidate가 남아 있으면 폐기 후 새로 저장 (replacedExisting=true)', async () => {
+    await autoApplyFeedbackViaShadow([
+      {
+        roleId: 'backend',
+        feedback: '# 첫 학습안',
+        origin: { source: 'project-feedback', projectId: 'p-1' },
+      },
+    ]);
+
+    const result = await autoApplyFeedbackViaShadow([
+      {
+        roleId: 'backend',
+        feedback: '# 두 번째 학습안',
+        origin: { source: 'project-feedback', projectId: 'p-2' },
+      },
+    ]);
+
+    expect(result[0].replacedExisting).toBe(true);
+    expect(await loadCandidateOverride('backend')).toContain('두 번째 학습안');
+
+    // provenance도 새로 시작 (이전 entries 폐기됨)
+    const prov = await loadCandidateProvenance('backend');
+    expect(prov.entries).toHaveLength(1);
+    expect(prov.entries[0].projectId).toBe('p-2');
+  });
+
+  it("origin이 명시되지 않으면 defaultOrigin('manual') 적용", async () => {
+    await autoApplyFeedbackViaShadow([{ roleId: 'backend', feedback: '# 학습안 (origin 없음)' }]);
+
+    const prov = await loadCandidateProvenance('backend');
+    expect(prov.entries[0].source).toBe('manual');
+  });
+
+  it('options.defaultOrigin override 적용', async () => {
+    await autoApplyFeedbackViaShadow([{ roleId: 'backend', feedback: '# 학습안' }], {
+      defaultOrigin: {
+        source: 'cross-project-pattern',
+        projectIds: ['p-a', 'p-b', 'p-c'],
+        pattern: 'edge-case',
+        repeatCount: 3,
+      },
+    });
+
+    const prov = await loadCandidateProvenance('backend');
+    expect(prov.entries[0].source).toBe('cross-project-pattern');
+    expect(prov.entries[0].pattern).toBe('edge-case');
+  });
+
+  it('빈/null 리스트는 빈 결과', async () => {
+    expect(await autoApplyFeedbackViaShadow([])).toEqual([]);
+    expect(await autoApplyFeedbackViaShadow(null)).toEqual([]);
+  });
+
+  it('feedback이 빈 항목은 건너뛴다', async () => {
+    const result = await autoApplyFeedbackViaShadow([
+      { roleId: 'backend', feedback: '' },
+      { roleId: 'frontend', feedback: '# 유효한 학습안' },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].roleId).toBe('frontend');
   });
 });


### PR DESCRIPTION
## Summary

자가발전 통합 첫 단계. 기존 \`autoApplyFeedback\`은 active override를 즉시 덮어써서 잘못된 학습이 다음 프로젝트들을 더 나쁘게 만들어도 회귀가 어렵습니다. 신규 \`autoApplyFeedbackViaShadow\`는 candidate로 격리 저장해 회귀 안전망(agent-shadow-mode)을 통과한 후에만 promote되게 합니다.

### 동작

\`\`\`
autoApplyFeedbackViaShadow(feedbackList, { defaultOrigin })
   ▼
각 항목별로
   ├─ loadCandidateOverride → 이전 candidate 있으면 discardCandidate (최신 우선)
   ├─ saveCandidateOverride(roleId, feedback, origin || defaultOrigin)
   └─ candidate provenance에 origin entry 자동 기록
   ▼
Array<{ roleId, candidatePath, entryId, replacedExisting }>
\`\`\`

### 주요 변화

- 기존 \`autoApplyFeedback\`은 그대로 유지 (하위 호환)
- 새 호출자는 \`autoApplyFeedbackViaShadow\` 선택 가능
- 이전 candidate가 평가 중이었다면 폐기 — 최신 학습 제안 우선 정책
- origin 미지정 시 \`options.defaultOrigin\` (기본 \`'manual'\`) 적용

### A-1 → A-2 → A-3 로드맵

| 단계 | 내용 |
|---|---|
| **A-1 (이 PR)** | autoApplyFeedbackViaShadow 도입 |
| A-2 | execution-loop에서 프로젝트 종료 시 \`recordProjectResult\` 자동 호출 |
| A-3 | shadow 평가(\`evaluateCandidate\`) + promote/discard 자동 실행 + CEO 노출 |

## Test plan

- [x] 6개 신규 테스트 그린 (active 격리 / candidate 교체 / defaultOrigin / 빈 입력)
- [x] 기존 5개 \`autoApplyFeedback\` 테스트 회귀 그린 (하위 호환 확인)
- [x] 전체 회귀: 136 files, 2999 pass / 2 skip
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)