### PR TITLE
feat(agent): 프로젝트 완료 시 자동 신호 기록 + candidate 평가 (자가발전 A-2/A-3)

### DIFF
--- a/scripts/lib/agent/project-completion-handler.js
+++ b/scripts/lib/agent/project-completion-handler.js
@@ -1,0 +1,182 @@
+/**
+ * project-completion-handler — 자가발전 통합 (A-2/A-3)
+ *
+ * 프로젝트가 'completed'로 전이될 때 호출되어 다음 흐름을 자동화한다:
+ *
+ *   1. 역할별 성과 추출 (extractAgentPerformance)
+ *   2. 6개 학습 신호 계산 (extractAllSignals)
+ *   3. 각 역할의 candidate가 있으면 recordProjectResult로 신호 누적
+ *   4. evaluateCandidate 호출 → promote / discard / pending 결정
+ *   5. promote 시 active 교체, discard 시 candidate 폐기
+ *   6. CEO 노출용 summary 반환
+ *
+ * candidate 평가는 active.md에는 손대지 않으므로(saveCandidateOverride 격리),
+ * 기존 실행 루프에는 sideeffect 없이 통합 가능. 호출 시점은 호출자가 결정.
+ */
+
+import { extractAgentPerformance } from './agent-feedback.js';
+import { extractAllSignals } from './agent-performance.js';
+import {
+  getCandidateState,
+  recordProjectResult,
+  evaluateCandidate,
+  promoteCandidate,
+  discardCandidate,
+} from './agent-shadow-mode.js';
+import { inputError } from '../core/validators.js';
+
+/**
+ * @typedef {Object} CandidateEvaluationResult
+ * @property {string} roleId
+ * @property {boolean} hadCandidate - 평가 시점에 candidate가 있었는지
+ * @property {object} signals - 이 프로젝트의 6개 신호
+ * @property {'promote' | 'discard' | 'pending' | 'skipped'} decision
+ *   skipped: candidate 자체가 없어서 평가 생략
+ * @property {string} reason
+ * @property {number} projectCount
+ * @property {number | null} activeScore
+ * @property {number | null} candidateScore
+ * @property {boolean} actionTaken - promote/discard가 실제 실행됐는지
+ */
+
+/**
+ * @typedef {Object} CompletionSummary
+ * @property {string} projectId
+ * @property {string} processedAt - ISO 8601
+ * @property {CandidateEvaluationResult[]} evaluations
+ * @property {{ promoted: number, discarded: number, pending: number, skipped: number }} totals
+ */
+
+/**
+ * 프로젝트 완료 처리. team의 모든 역할에 대해 신호를 기록하고 candidate를 평가한다.
+ *
+ * @param {object} project - 프로젝트 데이터 (team, tasks, executionState, metrics 포함)
+ * @param {{
+ *   minProjects?: number,
+ *   weights?: object,
+ *   autoApply?: boolean,
+ * }} [options]
+ *   - minProjects: evaluateCandidate 임계 (기본 3)
+ *   - weights: computeAggregateScore 가중치
+ *   - autoApply: true면 promote/discard를 실제 실행 (기본 true).
+ *       false면 결정만 반환하고 파일 변경 안 함 → CEO가 직접 처리하는 모드.
+ * @returns {Promise<CompletionSummary>}
+ */
+export async function processProjectCompletion(project, options = {}) {
+  if (!project || typeof project !== 'object') {
+    throw inputError('project 객체가 필요합니다');
+  }
+  const projectId = project.id;
+  if (typeof projectId !== 'string' || !projectId) {
+    throw inputError('project.id가 필요합니다');
+  }
+
+  const autoApply = options.autoApply !== false;
+  const evalOptions = {};
+  if (typeof options.minProjects === 'number') evalOptions.minProjects = options.minProjects;
+  if (options.weights) evalOptions.weights = options.weights;
+
+  const performances = extractAgentPerformance(project);
+  const evaluations = [];
+
+  for (const performance of performances) {
+    const roleId = performance.roleId;
+    const signals = extractAllSignals(project, performance);
+    const state = await getCandidateState(roleId);
+
+    if (!state.exists) {
+      evaluations.push({
+        roleId,
+        hadCandidate: false,
+        signals,
+        decision: 'skipped',
+        reason: 'candidate 없음 — 평가 생략',
+        projectCount: 0,
+        activeScore: null,
+        candidateScore: null,
+        actionTaken: false,
+      });
+      continue;
+    }
+
+    // 신호 누적 (이 프로젝트는 dry-run 평가 대상)
+    await recordProjectResult(roleId, projectId, signals);
+
+    // 평가
+    const result = await evaluateCandidate(roleId, evalOptions);
+    let actionTaken = false;
+    if (autoApply) {
+      if (result.decision === 'promote') {
+        await promoteCandidate(roleId);
+        actionTaken = true;
+      } else if (result.decision === 'discard') {
+        await discardCandidate(roleId);
+        actionTaken = true;
+      }
+    }
+
+    evaluations.push({
+      roleId,
+      hadCandidate: true,
+      signals,
+      decision: result.decision,
+      reason: result.reason,
+      projectCount: result.projectCount,
+      activeScore: result.activeScore,
+      candidateScore: result.candidateScore,
+      actionTaken,
+    });
+  }
+
+  const totals = { promoted: 0, discarded: 0, pending: 0, skipped: 0 };
+  for (const e of evaluations) {
+    if (e.decision === 'promote') totals.promoted++;
+    else if (e.decision === 'discard') totals.discarded++;
+    else if (e.decision === 'pending') totals.pending++;
+    else if (e.decision === 'skipped') totals.skipped++;
+  }
+
+  return {
+    projectId,
+    processedAt: new Date().toISOString(),
+    evaluations,
+    totals,
+  };
+}
+
+/**
+ * CompletionSummary를 사람 읽기 좋은 마크다운으로 포맷한다 (CEO 노출용).
+ * @param {CompletionSummary} summary
+ * @returns {string}
+ */
+export function formatCompletionSummary(summary) {
+  if (!summary || !summary.evaluations) return '';
+  const lines = [
+    `# 자가발전 학습 평가 — ${summary.projectId}`,
+    '',
+    `평가 시각: ${summary.processedAt}`,
+    '',
+    `**요약**: promote ${summary.totals.promoted} · discard ${summary.totals.discarded} · pending ${summary.totals.pending} · skipped ${summary.totals.skipped}`,
+    '',
+  ];
+
+  const active = summary.evaluations.filter((e) => e.decision !== 'skipped');
+  if (active.length === 0) {
+    lines.push('활성 candidate가 있는 역할이 없습니다.');
+    return lines.join('\n');
+  }
+
+  lines.push('## 역할별 결정', '');
+  for (const e of active) {
+    const scores =
+      e.activeScore !== null && e.candidateScore !== null
+        ? ` (active ${e.activeScore.toFixed(3)} · candidate ${e.candidateScore.toFixed(3)})`
+        : e.candidateScore !== null
+          ? ` (candidate ${e.candidateScore.toFixed(3)}, active baseline 없음)`
+          : '';
+    const action = e.actionTaken ? ' ✅' : '';
+    lines.push(`- **${e.roleId}** — ${e.decision}${scores}${action}`);
+    lines.push(`  - 누적 ${e.projectCount}개 프로젝트 · ${e.reason}`);
+  }
+  return lines.join('\n');
+}

--- a/tests/project-completion-handler.test.js
+++ b/tests/project-completion-handler.test.js
@@ -1,0 +1,286 @@
+/**
+ * project-completion-handler — 프로젝트 종료 시 자동 신호 기록 + 평가 + promote/discard
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, readFile } from 'fs/promises';
+import { resolve } from 'path';
+import {
+  processProjectCompletion,
+  formatCompletionSummary,
+} from '../scripts/lib/agent/project-completion-handler.js';
+import { setOverridesDir, saveAgentOverride } from '../scripts/lib/agent/agent-feedback.js';
+import {
+  setShadowDir,
+  saveCandidateOverride,
+  loadCandidateOverride,
+  recordProjectResult,
+  getCandidateState,
+} from '../scripts/lib/agent/agent-shadow-mode.js';
+import { setProvenanceDir, loadProvenance } from '../scripts/lib/agent/agent-provenance.js';
+
+const TMP_DIR = resolve('.tmp-test-project-completion-handler');
+
+beforeEach(async () => {
+  await mkdir(TMP_DIR, { recursive: true });
+  setOverridesDir(TMP_DIR);
+  setShadowDir(TMP_DIR);
+  setProvenanceDir(TMP_DIR);
+});
+
+afterEach(async () => {
+  await rm(TMP_DIR, { recursive: true, force: true });
+});
+
+/**
+ * 테스트용 프로젝트 fixture. team에 명시한 역할들에 대해
+ * 각 역할 1개 task + 1개 review + 옵션으로 issue를 부여한다.
+ */
+function buildProject(projectId, roles, options = {}) {
+  const tasks = roles.map((roleId, idx) => ({
+    id: `t-${idx}`,
+    title: `${roleId} task`,
+    assignee: roleId,
+    phase: 1,
+    status: 'completed',
+    reviews: [
+      {
+        approved: false,
+        issues: (options.issuesByRole?.[roleId] || []).map((sev) => ({
+          severity: sev,
+          description: `${roleId} ${sev} issue`,
+        })),
+      },
+    ],
+  }));
+  return {
+    id: projectId,
+    name: 'Sample',
+    type: 'cli-app',
+    mode: 'quick-build',
+    status: 'completed',
+    team: roles.map((roleId) => ({ roleId, model: 'sonnet' })),
+    tasks,
+    metrics: { totalCost: options.cost ?? 0 },
+    executionState: {
+      journal: options.journal || [],
+    },
+  };
+}
+
+const SAMPLE_ORIGIN = { source: 'project-feedback', projectId: 'p-source' };
+
+describe('processProjectCompletion', () => {
+  it('candidate 없는 역할은 skipped 결정', async () => {
+    const project = buildProject('p-1', ['cto', 'qa']);
+    const summary = await processProjectCompletion(project);
+
+    expect(summary.totals.skipped).toBe(2);
+    expect(summary.evaluations.every((e) => e.decision === 'skipped')).toBe(true);
+    expect(summary.evaluations.every((e) => e.actionTaken === false)).toBe(true);
+  });
+
+  it('candidate 있는 역할은 신호 기록 + 평가 (pending 단계)', async () => {
+    await saveCandidateOverride('cto', '# CTO candidate', SAMPLE_ORIGIN);
+
+    const project = buildProject('p-1', ['cto'], {
+      issuesByRole: { cto: ['critical'] },
+    });
+    const summary = await processProjectCompletion(project);
+
+    const cto = summary.evaluations.find((e) => e.roleId === 'cto');
+    expect(cto.hadCandidate).toBe(true);
+    expect(cto.decision).toBe('pending'); // 1/3
+    expect(cto.projectCount).toBe(1);
+    expect(cto.signals.quality).toBe(3); // critical * 3
+    expect(cto.actionTaken).toBe(false);
+  });
+
+  it('3개 프로젝트 누적 후 promote 자동 실행 (active baseline 없음)', async () => {
+    await saveCandidateOverride('cto', '# CTO candidate', SAMPLE_ORIGIN);
+
+    for (let i = 1; i <= 3; i++) {
+      const project = buildProject(`p-${i}`, ['cto'], {
+        issuesByRole: { cto: [] },
+      });
+      const summary = await processProjectCompletion(project);
+      const cto = summary.evaluations[0];
+      if (i < 3) {
+        expect(cto.decision).toBe('pending');
+      } else {
+        expect(cto.decision).toBe('promote');
+        expect(cto.actionTaken).toBe(true);
+      }
+    }
+
+    // promote 결과 확인 — active.md가 candidate 내용으로 교체됨
+    const active = await readFile(resolve(TMP_DIR, 'cto.md'), 'utf-8');
+    expect(active).toBe('# CTO candidate');
+    // candidate 파일은 정리됨
+    expect(await loadCandidateOverride('cto')).toBeNull();
+  });
+
+  it('candidate가 active보다 열등하면 discard 자동 실행', async () => {
+    // active baseline: 좋은 신호 (quality 0)
+    for (let i = 1; i <= 3; i++) {
+      await recordProjectResult(
+        'cto',
+        `active-p-${i}`,
+        { quality: 0, time: 0, cost: 0, retry: 0, escalation: 0, contribution: 1 },
+        { which: 'active' },
+      );
+    }
+    // 기존 active.md
+    await saveAgentOverride('cto', '# OLD ACTIVE');
+
+    // candidate: 나쁜 신호로 평가될 예정
+    await saveCandidateOverride('cto', '# WORSE CANDIDATE', SAMPLE_ORIGIN);
+
+    for (let i = 1; i <= 3; i++) {
+      const project = buildProject(`cand-p-${i}`, ['cto'], {
+        issuesByRole: { cto: ['critical', 'critical'] },
+      });
+      await processProjectCompletion(project);
+    }
+
+    // candidate 폐기됨, active 보존
+    expect(await loadCandidateOverride('cto')).toBeNull();
+    const active = await readFile(resolve(TMP_DIR, 'cto.md'), 'utf-8');
+    expect(active).toBe('# OLD ACTIVE');
+  });
+
+  it('autoApply=false면 결정만 반환하고 파일 변경 안 함', async () => {
+    await saveCandidateOverride('cto', '# CTO candidate', SAMPLE_ORIGIN);
+    for (let i = 1; i <= 3; i++) {
+      const project = buildProject(`p-${i}`, ['cto']);
+      const summary = await processProjectCompletion(project, { autoApply: false });
+      const cto = summary.evaluations[0];
+      if (i === 3) {
+        expect(cto.decision).toBe('promote');
+        expect(cto.actionTaken).toBe(false); // 실제 적용 안 함
+      }
+    }
+
+    // candidate.md 그대로 살아있음
+    expect(await loadCandidateOverride('cto')).toBe('# CTO candidate');
+    // active.md는 생성되지 않음
+    const state = await getCandidateState('cto');
+    expect(state.projectCount).toBe(3);
+  });
+
+  it('minProjects override 적용', async () => {
+    await saveCandidateOverride('cto', '# CTO candidate', SAMPLE_ORIGIN);
+    const project = buildProject('p-1', ['cto']);
+    const summary = await processProjectCompletion(project, { minProjects: 1 });
+
+    expect(summary.evaluations[0].decision).toBe('promote');
+  });
+
+  it('여러 역할을 한 번에 처리', async () => {
+    await saveCandidateOverride('cto', '# CTO cand', SAMPLE_ORIGIN);
+    await saveCandidateOverride('qa', '# QA cand', SAMPLE_ORIGIN);
+    // backend는 candidate 없음
+
+    const project = buildProject('p-1', ['cto', 'qa', 'backend']);
+    const summary = await processProjectCompletion(project);
+
+    expect(summary.evaluations).toHaveLength(3);
+    const byRole = Object.fromEntries(summary.evaluations.map((e) => [e.roleId, e]));
+    expect(byRole.cto.hadCandidate).toBe(true);
+    expect(byRole.qa.hadCandidate).toBe(true);
+    expect(byRole.backend.hadCandidate).toBe(false);
+    expect(byRole.backend.decision).toBe('skipped');
+  });
+
+  it('promote 후 active provenance에 candidate.projectResults 보존', async () => {
+    await saveCandidateOverride('cto', '# new', {
+      source: 'project-feedback',
+      projectId: 'p-source',
+    });
+    for (let i = 1; i <= 3; i++) {
+      const project = buildProject(`p-${i}`, ['cto'], {
+        issuesByRole: { cto: ['important'] },
+      });
+      await processProjectCompletion(project);
+    }
+
+    const prov = await loadProvenance('cto');
+    const inheritedFeedback = prov.entries.filter((e) => e.source === 'project-feedback');
+    // 누적된 3개 + origin 1개 = 4개 (전부 project-feedback)
+    expect(inheritedFeedback.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('project.id 누락 거부', async () => {
+    const project = { team: [], tasks: [] };
+    await expect(processProjectCompletion(project)).rejects.toThrow('project.id');
+  });
+
+  it('null project 거부', async () => {
+    await expect(processProjectCompletion(null)).rejects.toThrow('project 객체');
+  });
+});
+
+describe('formatCompletionSummary', () => {
+  it('skipped만 있으면 "활성 candidate 없음" 표시', () => {
+    const summary = {
+      projectId: 'p-1',
+      processedAt: '2026-04-28T00:00:00Z',
+      totals: { promoted: 0, discarded: 0, pending: 0, skipped: 2 },
+      evaluations: [
+        { roleId: 'cto', decision: 'skipped' },
+        { roleId: 'qa', decision: 'skipped' },
+      ],
+    };
+    const md = formatCompletionSummary(summary);
+    expect(md).toContain('활성 candidate가 있는 역할이 없습니다');
+    expect(md).toContain('p-1');
+  });
+
+  it('promote/discard/pending 결과를 점수와 함께 표시', () => {
+    const summary = {
+      projectId: 'p-1',
+      processedAt: '2026-04-28T00:00:00Z',
+      totals: { promoted: 1, discarded: 1, pending: 1, skipped: 0 },
+      evaluations: [
+        {
+          roleId: 'cto',
+          decision: 'promote',
+          activeScore: -10,
+          candidateScore: -5,
+          projectCount: 3,
+          reason: 'candidate 우수',
+          actionTaken: true,
+        },
+        {
+          roleId: 'qa',
+          decision: 'discard',
+          activeScore: -2,
+          candidateScore: -8,
+          projectCount: 3,
+          reason: 'candidate 열등',
+          actionTaken: true,
+        },
+        {
+          roleId: 'security',
+          decision: 'pending',
+          activeScore: null,
+          candidateScore: null,
+          projectCount: 1,
+          reason: '1/3',
+          actionTaken: false,
+        },
+      ],
+    };
+    const md = formatCompletionSummary(summary);
+    expect(md).toContain('cto');
+    expect(md).toContain('promote');
+    expect(md).toContain('candidate -5');
+    expect(md).toContain('discard');
+    expect(md).toContain('pending');
+    expect(md).toContain('promote 1 · discard 1 · pending 1');
+  });
+
+  it('빈 summary는 빈 문자열', () => {
+    expect(formatCompletionSummary(null)).toBe('');
+    expect(formatCompletionSummary({})).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

프로젝트 완료 시점에 자가발전 루프를 자동 실행하는 통합 핸들러. PR #273(신호) + PR #275(shadow) + PR #276(autoApplyFeedbackViaShadow)을 연결합니다.

### processProjectCompletion(project, options)

\`\`\`
프로젝트 'completed' 전이
   ▼
extractAgentPerformance(project)
   ▼ 역할별로
extractAllSignals(project, performance) → 6개 신호
   ▼
getCandidateState(roleId)
   ├─ exists=false → 'skipped' (평가 생략)
   └─ exists=true
        ▼
        recordProjectResult(roleId, projectId, signals)
        ▼
        evaluateCandidate(roleId, { minProjects, weights })
        ├─ 'promote'  → autoApply 시 promoteCandidate 실행
        ├─ 'discard'  → autoApply 시 discardCandidate 실행
        └─ 'pending'  → 다음 프로젝트로 이월
\`\`\`

### CompletionSummary

\`\`\`js
{
  projectId,
  processedAt,
  evaluations: [
    { roleId, hadCandidate, signals, decision, projectCount, activeScore, candidateScore, actionTaken }
  ],
  totals: { promoted, discarded, pending, skipped }
}
\`\`\`

\`formatCompletionSummary\`로 CEO 노출용 마크다운 생성 — 각 역할의 결정과 점수, 누적 프로젝트 수 표시.

### 안전 옵션

- \`autoApply: false\` — 결정만 반환, 파일 변경 없음 (CEO가 직접 처리)
- \`minProjects\` override — 기본 3 (config 값)
- \`weights\` override — DEFAULT_SIGNAL_WEIGHTS 기반 합성

## Test plan

- [x] 13개 단위 테스트 그린 (skipped / pending / promote / discard / autoApply=false / multi-role / promote 후 baseline 보존)
- [x] 전체 회귀: 137 files, 3012 pass / 2 skip
- [ ] CI green 확인

## 다음 단계

| 단계 | 내용 |
|---|---|
| ~~A-1~~ ✅ | autoApplyFeedbackViaShadow (PR #276) |
| ~~A-2/A-3~~ ⏳ | processProjectCompletion (이 PR) |
| **A-4** | project-manager의 \`updateProjectStatus(status='completed')\`에 훅 연결 — 실제 자동 실행 활성화 |
| A-5 | CEO UI: \`/gv:status\` 또는 \`/gv:agent-history\`에 CompletionSummary 노출 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)