### PR TITLE
feat(handlers): evaluate-completion CLI 노출 (자가발전 A-4)

### DIFF
--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -138,6 +138,8 @@ const COMMAND_MAP = {
   'list-project-overrides': 'feedback',
   'merge-all-overrides': 'feedback',
   'analyze-messages': 'feedback',
+  'evaluate-completion': 'feedback',
+  'format-completion-summary': 'feedback',
   // infra
   'setup-project-infra': 'infra',
   'check-gh-status': 'infra',

--- a/scripts/handlers/feedback.js
+++ b/scripts/handlers/feedback.js
@@ -21,6 +21,10 @@ import {
   analyzeMessagePatterns,
   generateMessageAnalysisSection,
 } from '../lib/engine/message-analyzer.js';
+import {
+  processProjectCompletion,
+  formatCompletionSummary,
+} from '../lib/agent/project-completion-handler.js';
 
 const [, , , ...args] = process.argv;
 
@@ -114,5 +118,28 @@ export const commands = {
       const section = generateMessageAnalysisSection(analysis);
       output({ ...analysis, section });
     });
+  },
+
+  // 자가발전: 프로젝트 완료 시 모든 candidate를 평가하고 promote/discard 자동 실행.
+  // --id={projectId} 필수. stdin으로 옵션 전달 가능: { autoApply, minProjects, weights }.
+  'evaluate-completion': async () => {
+    const opts = parseArgs(args);
+    const stdinOpts = (await readStdin()) || {};
+    await withProject(opts.id, async (project) => {
+      const summary = await processProjectCompletion(project, {
+        autoApply: stdinOpts.autoApply !== false,
+        minProjects: stdinOpts.minProjects,
+        weights: stdinOpts.weights,
+      });
+      output(summary);
+    });
+  },
+
+  // CompletionSummary를 CEO 노출용 마크다운으로 변환. stdin: { summary }.
+  'format-completion-summary': async () => {
+    const data = await readStdin();
+    requireFields(data, ['summary']);
+    const markdown = formatCompletionSummary(data.summary);
+    output({ markdown });
   },
 };

--- a/tests/handlers/feedback.test.js
+++ b/tests/handlers/feedback.test.js
@@ -91,4 +91,33 @@ describe('handlers/feedback', () => {
     const result = cliExec('list-agent-overrides', {});
     expect(Array.isArray(result)).toBe(true);
   });
+
+  it('evaluate-completion → --id 누락 시 에러 종료', () => {
+    const result = cliExecRaw('evaluate-completion', {});
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('evaluate-completion → 존재하지 않는 프로젝트 NOT_FOUND', () => {
+    const result = cliExecRaw('evaluate-completion --id nonexistent-project-id', {});
+    expect(result.exitCode).toBe(3);
+    expect(result.stderr).toContain('NOT_FOUND');
+  });
+
+  it('format-completion-summary → summary 필수 검증', () => {
+    const result = cliExecRaw('format-completion-summary', {});
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('summary');
+  });
+
+  it('format-completion-summary → 빈 evaluations 시 안내 문구', () => {
+    const result = cliExec('format-completion-summary', {
+      summary: {
+        projectId: 'p-test',
+        processedAt: '2026-04-28T00:00:00Z',
+        totals: { promoted: 0, discarded: 0, pending: 0, skipped: 0 },
+        evaluations: [],
+      },
+    });
+    expect(result.markdown).toContain('p-test');
+  });
 });


### PR DESCRIPTION
## Summary

A-2/A-3 (PR #277)의 \`processProjectCompletion\`을 CLI 커맨드로 노출. 메인 세션이나 자동화 트리거에서 즉시 호출 가능합니다.

### 신규 커맨드

| 커맨드 | 입력 | 출력 |
|---|---|---|
| \`evaluate-completion --id={projectId}\` | stdin \`{ autoApply?, minProjects?, weights? }\` | CompletionSummary JSON |
| \`format-completion-summary\` | stdin \`{ summary }\` | \`{ markdown }\` |

\`evaluate-completion\`은 \`withProject\` helper로 프로젝트 영속화를 처리하고, \`autoApply: false\` 옵션으로 결정만 보고 받는 dry-run도 가능.

### 사용 예시

\`\`\`bash
# 자동 적용
node scripts/cli.js evaluate-completion --id=proj-2026-04-abc <<< '{}'

# 결정만 (dry-run)
node scripts/cli.js evaluate-completion --id=proj-2026-04-abc <<< '{"autoApply":false}'

# 마크다운 포맷
node scripts/cli.js evaluate-completion --id=proj-2026-04-abc \
  | node scripts/cli.js format-completion-summary
\`\`\`

### A 시리즈 진행

| 단계 | 상태 |
|---|---|
| A-1 autoApplyFeedbackViaShadow | ✅ #276 |
| A-2/A-3 processProjectCompletion | ✅ #277 |
| **A-4 CLI 노출 (이 PR)** | ⏳ |
| A-5 /gv:status에 노출 + 그래프 done state 자동 호출 | 다음 |

## Test plan

- [x] 핸들러 E2E 테스트 4개 추가 (필수 검증 / NOT_FOUND / 빈 evaluations 안내)
- [x] 전체 회귀: 137 files, 3016 pass / 2 skip
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)