### PR TITLE
feat(status): /gv:status에 자가발전 학습 진행 노출 (자가발전 A-5a)

### DIFF
--- a/commands/gv-status.md
+++ b/commands/gv-status.md
@@ -11,13 +11,21 @@ description: '진행 중인 작업과 프로젝트 상태를 한눈에 표시 (v
 
 ## 실행 흐름
 
-### Step 1: 프로젝트 목록 조회 (Thin Controller — CLI 1회)
+### Step 1: 프로젝트 목록 조회 (단순 CLI 1회)
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/cli.js" list-projects
 ```
 
-### Step 2: 결과 표시
+### Step 2: 활성 자가발전 candidate 조회 (단순 CLI 1회)
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cli.js" list-shadow-candidates
+```
+
+각 항목: `{ roleId, projectCount, projectIds, entryCount }`. `projectCount / 3` (기본 minProjects)으로 학습 진행률 표시.
+
+### Step 3: 결과 표시
 
 CEO에게 다음을 한 번에 표시:
 
@@ -29,5 +37,9 @@ CEO에게 다음을 한 번에 표시:
    - `executing` / `reviewing` → `/gv:resume` (또는 `/gv 이전 작업 이어서`)
    - `completed` → `/gv 보고서 확인` / `/gv 피드백 분석` / `/gv 수정 요청 ...`
 3. **전체 프로젝트 목록** (최대 10개, 최근순)
+4. **자가발전 학습 진행** (활성 candidate가 있을 때만)
+   - 각 역할별 `roleId · projectCount/3` 형식 (예: `cto · 2/3`)
+   - 비어있으면 이 섹션 자체 생략
+   - `evaluate-completion`이 다음 프로젝트 완료 시 자동으로 promote/discard 결정함을 안내
 
-추가 작업/판단/LLM 호출 금지. 단일 CLI 결과를 그대로 가공 없이 표시.
+추가 작업/판단/LLM 호출 금지. 두 단순 조회 CLI 결과를 그대로 가공 없이 표시.

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -140,6 +140,7 @@ const COMMAND_MAP = {
   'analyze-messages': 'feedback',
   'evaluate-completion': 'feedback',
   'format-completion-summary': 'feedback',
+  'list-shadow-candidates': 'feedback',
   // infra
   'setup-project-infra': 'infra',
   'check-gh-status': 'infra',

--- a/scripts/handlers/feedback.js
+++ b/scripts/handlers/feedback.js
@@ -25,6 +25,7 @@ import {
   processProjectCompletion,
   formatCompletionSummary,
 } from '../lib/agent/project-completion-handler.js';
+import { listActiveCandidates } from '../lib/agent/agent-shadow-mode.js';
 
 const [, , , ...args] = process.argv;
 
@@ -141,5 +142,11 @@ export const commands = {
     requireFields(data, ['summary']);
     const markdown = formatCompletionSummary(data.summary);
     output({ markdown });
+  },
+
+  // 활성 candidate 목록 — /gv:status에서 학습 진행 상황 노출용.
+  'list-shadow-candidates': async () => {
+    const candidates = await listActiveCandidates();
+    output(candidates);
   },
 };

--- a/scripts/lib/agent/agent-shadow-mode.js
+++ b/scripts/lib/agent/agent-shadow-mode.js
@@ -20,7 +20,7 @@
  * 실제 dry-run 실행(execution loop 통합)은 후속 PR. 이 모듈은 데이터 구조 + 의사결정 로직만.
  */
 
-import { readFile, writeFile, unlink } from 'fs/promises';
+import { readFile, writeFile, unlink, readdir } from 'fs/promises';
 import { resolve } from 'path';
 import { ensureDir, fileExists } from '../core/file-writer.js';
 import { agentOverridesDir } from '../core/app-paths.js';
@@ -385,4 +385,36 @@ async function unlinkIfExists(path) {
   if (await fileExists(path)) {
     await unlink(path);
   }
+}
+
+/**
+ * 활성 candidate가 있는 모든 역할의 상태를 열거한다 (CEO 노출용).
+ * overridesDir에서 `*.candidate.md` 파일을 스캔하여 각각의 getCandidateState를 반환.
+ *
+ * 디렉토리가 없으면 빈 배열 반환 (graceful).
+ *
+ * @returns {Promise<Array<{ roleId: string, projectCount: number, projectIds: string[], entryCount: number }>>}
+ */
+export async function listActiveCandidates() {
+  let entries;
+  try {
+    entries = await readdir(overridesDir);
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+
+  const roleIds = entries
+    .filter((name) => name.endsWith('.candidate.md'))
+    .map((name) => name.slice(0, -'.candidate.md'.length))
+    .filter((roleId) => VALID_ROLE_PATTERN.test(roleId));
+
+  const results = [];
+  for (const roleId of roleIds) {
+    const state = await getCandidateState(roleId);
+    if (state.exists) {
+      results.push({ roleId, ...state });
+    }
+  }
+  return results;
 }

--- a/tests/agent-shadow-mode.test.js
+++ b/tests/agent-shadow-mode.test.js
@@ -15,6 +15,7 @@ import {
   promoteCandidate,
   discardCandidate,
   getCandidateState,
+  listActiveCandidates,
   DEFAULT_MIN_SHADOW_PROJECTS,
 } from '../scripts/lib/agent/agent-shadow-mode.js';
 import { setProvenanceDir, loadProvenance } from '../scripts/lib/agent/agent-provenance.js';
@@ -297,6 +298,48 @@ describe('getCandidateState', () => {
     expect(state.projectCount).toBe(2);
     expect(state.projectIds).toEqual(['p-1', 'p-2']);
     expect(state.entryCount).toBe(1); // origin entry 1개
+  });
+});
+
+describe('listActiveCandidates', () => {
+  it('overrides 디렉토리가 없으면 빈 배열', async () => {
+    await rm(TMP_DIR, { recursive: true, force: true });
+    const result = await listActiveCandidates();
+    expect(result).toEqual([]);
+  });
+
+  it('candidate가 없으면 빈 배열', async () => {
+    expect(await listActiveCandidates()).toEqual([]);
+  });
+
+  it('여러 역할의 candidate를 모두 열거', async () => {
+    await saveCandidateOverride('cto', '# cto', SAMPLE_ORIGIN);
+    await saveCandidateOverride('qa', '# qa', SAMPLE_ORIGIN);
+    await recordProjectResult('cto', 'p-1', fixtureSignals());
+    await recordProjectResult('cto', 'p-2', fixtureSignals());
+
+    const result = await listActiveCandidates();
+    expect(result).toHaveLength(2);
+    const byRole = Object.fromEntries(result.map((r) => [r.roleId, r]));
+    expect(byRole.cto.projectCount).toBe(2);
+    expect(byRole.qa.projectCount).toBe(0);
+  });
+
+  it('잘못된 roleId 패턴의 파일은 무시', async () => {
+    await saveCandidateOverride('cto', '# cto', SAMPLE_ORIGIN);
+    // 잘못된 패턴의 파일을 직접 만들어도 무시되어야 함
+    await writeFile(resolve(TMP_DIR, 'INVALID-Role.candidate.md'), '# x', 'utf-8');
+
+    const result = await listActiveCandidates();
+    expect(result).toHaveLength(1);
+    expect(result[0].roleId).toBe('cto');
+  });
+
+  it('active.md만 있는 역할은 제외 (candidate가 핵심 조건)', async () => {
+    await writeFile(resolve(TMP_DIR, 'cto.md'), '# active only', 'utf-8');
+
+    const result = await listActiveCandidates();
+    expect(result).toEqual([]);
   });
 });
 

--- a/tests/handlers/feedback.test.js
+++ b/tests/handlers/feedback.test.js
@@ -120,4 +120,9 @@ describe('handlers/feedback', () => {
     });
     expect(result.markdown).toContain('p-test');
   });
+
+  it('list-shadow-candidates → 배열 반환 (candidate 없으면 빈 배열)', () => {
+    const result = cliExec('list-shadow-candidates', {});
+    expect(Array.isArray(result)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

CEO가 활성 candidate의 학습 진행 상황을 \`/gv:status\`에서 확인할 수 있도록 read-only 가시성을 추가합니다.

### 변경

- **\`listActiveCandidates()\`** in agent-shadow-mode
  - overrides 디렉토리에서 \`*.candidate.md\` 스캔
  - 각 roleId의 \`getCandidateState\` 반환
  - ENOENT graceful, 잘못된 roleId 패턴 무시
- **\`list-shadow-candidates\`** CLI 커맨드
- **\`/gv:status\` 가이드** Step 2 + Step 3 보강
  - 두 단순 조회 CLI(\`list-projects\` + \`list-shadow-candidates\`) 호출
  - 비어있으면 섹션 자체 생략 → 일반 사용자 노이즈 0

### CEO 화면 예시

\`\`\`
## 자가발전 학습 진행
- cto · 2/3 (다음 프로젝트 완료 시 평가)
- qa  · 1/3
\`\`\`

\`projectCount / 3\` 형식으로 학습 진행률 표시. \`evaluate-completion\`이 다음 프로젝트 완료 시 자동으로 promote/discard 결정.

### A 시리즈 진행

| 단계 | 상태 |
|---|---|
| A-1 autoApplyFeedbackViaShadow | ✅ #276 |
| A-2/A-3 processProjectCompletion | ✅ #277 |
| A-4 CLI 노출 | ✅ #278 |
| **A-5a /gv:status 노출 (이 PR)** | ⏳ |
| A-5b gv-execute 자동 트리거 (별도 PR) | 다음 |

## Test plan

- [x] 5개 단위 테스트 추가 (ENOENT / 빈 / 다중 역할 / 잘못된 패턴 무시 / active만 있는 경우)
- [x] 핸들러 E2E 테스트 1개 추가 (\`list-shadow-candidates\` 배열 반환)
- [x] 전체 회귀: 137 files, 3022 pass / 2 skip
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)