### PR TITLE
feat(handlers): gv-execute에 자가발전 자동 평가 옵션 (자가발전 A-5b)

### DIFF
--- a/scripts/handlers/gv-execute.js
+++ b/scripts/handlers/gv-execute.js
@@ -12,6 +12,8 @@ import { selectGraph } from '../lib/engine/task-graph-presets.js';
 import { renderPanel } from '../lib/output/claude-panel-renderer.js';
 import { callLLMWithFallback } from '../lib/llm/llm-fallback.js';
 import { inputError } from '../lib/core/validators.js';
+import { getProject } from '../lib/project/project-manager.js';
+import { processProjectCompletion } from '../lib/agent/project-completion-handler.js';
 
 export const commands = {
   'gv-execute': async () => {
@@ -57,6 +59,27 @@ export const commands = {
       recentEvents: events,
     });
 
+    // 자가발전 자동 평가 (옵트인) — 그래프 success + projectId 명시 시
+    // processProjectCompletion 인-프로세스 호출. 평가 실패는 grace 처리하여
+    // 그래프 결과를 깨뜨리지 않는다 (try/catch + 응답에 evaluationError 필드).
+    let completionSummary = null;
+    let evaluationError = null;
+    if (data.evaluateOnComplete === true && result.success && data.projectId) {
+      try {
+        const project = await getProject(data.projectId);
+        if (project) {
+          completionSummary = await processProjectCompletion(project, {
+            autoApply: data.autoApplyShadow !== false,
+            minProjects: data.minShadowProjects,
+          });
+        } else {
+          evaluationError = `project not found: ${data.projectId}`;
+        }
+      } catch (err) {
+        evaluationError = err.message;
+      }
+    }
+
     output({
       success: result.success,
       finalState: result.finalState,
@@ -64,6 +87,8 @@ export const commands = {
       reason: result.reason,
       history: result.history,
       panel,
+      completionSummary,
+      evaluationError,
     });
   },
 };

--- a/tests/handlers/gv-execute.test.js
+++ b/tests/handlers/gv-execute.test.js
@@ -67,4 +67,31 @@ describe('handlers/gv-execute — E2E', () => {
       });
     });
   });
+
+  describe('자가발전 자동 평가 (evaluateOnComplete)', () => {
+    it('기본은 평가 안 함 → completionSummary=null', () => {
+      const r = exec('gv-execute', { taskRoute: { taskType: 'ask' } });
+      expect(r.completionSummary).toBeNull();
+      expect(r.evaluationError).toBeNull();
+    });
+
+    it('evaluateOnComplete=true이지만 projectId 없으면 평가 생략', () => {
+      const r = exec('gv-execute', {
+        taskRoute: { taskType: 'ask' },
+        evaluateOnComplete: true,
+      });
+      expect(r.completionSummary).toBeNull();
+      expect(r.evaluationError).toBeNull();
+    });
+
+    it('evaluateOnComplete=true + 존재하지 않는 projectId → evaluationError', () => {
+      const r = exec('gv-execute', {
+        taskRoute: { taskType: 'ask' },
+        evaluateOnComplete: true,
+        projectId: 'nonexistent-project-id-for-test',
+      });
+      expect(r.completionSummary).toBeNull();
+      expect(r.evaluationError).toMatch(/not found|nonexistent/i);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

\`gv-execute\` 핸들러에 \`evaluateOnComplete\` 옵션을 추가합니다. 그래프 실행 후 in-process로 자가발전 평가를 트리거할 수 있어, 호출자(주로 Claude Code 메인 세션)가 옵트인 한 번으로 자가발전 루프를 활성화합니다.

### 입력 옵션 (모두 선택적, 기본 비활성)

| 옵션 | 기본 | 설명 |
|---|---|---|
| \`evaluateOnComplete\` | \`false\` | true일 때 그래프 success + projectId 모두 만족하면 자동 평가 |
| \`projectId\` | — | 평가 대상 프로젝트 |
| \`autoApplyShadow\` | \`true\` | false면 결정만 보고 (promote/discard 실행 안 함) |
| \`minShadowProjects\` | 3 | shadow 평가 임계 |

### 응답 추가 필드

| 필드 | 타입 |
|---|---|
| \`completionSummary\` | CompletionSummary 또는 null |
| \`evaluationError\` | 실패 시 메시지 (그래프 결과는 보존) |

### 안전 설계

- 평가는 in-process 호출 (CLI 재진입 비용 0)
- 실패는 try/catch 격리 — 그래프 결과 깨뜨리지 않음
- 옵트인 방식 — 기본 동작 변화 0 (하위 호환)

### Tier 1 자가발전 통합 시리즈 완료

| PR | 기능 |
|---|---|
| #273 | multi-dim signals (#2) |
| #274 | provenance (#3) |
| #275 | shadow mode (#1) |
| #276 | autoApplyFeedbackViaShadow (A-1) |
| #277 | processProjectCompletion (A-2/A-3) |
| #278 | CLI 노출 (A-4) |
| #279 | /gv:status 가시성 (A-5a) |
| **이 PR** | gv-execute 자동 평가 옵션 (A-5b) |

## Test plan

- [x] 3개 단위 테스트 추가 (기본 비활성 / projectId 없음 / 존재하지 않는 projectId)
- [x] 전체 회귀: 137 files, 3025 pass / 2 skip
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)