### PR TITLE
feat(shortcuts): unprefixed 슬래시 단축어 설치 명령 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI 팀을 구성하여 프로젝트를 기획-토론-실행-리뷰하는 멀티에이전트 플랫폼",
-    "version": "2.0.0-rc.2"
+    "version": "2.0.0-rc.3"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "url": "https://github.com/sumsun-dev/good-vibe-coding.git"
       },
       "description": "AI 팀을 구성하고 프로젝트를 관리하세요. CEO가 되어 가상 AI 팀원들과 기획부터 실행까지.",
-      "version": "2.0.0-rc.2",
+      "version": "2.0.0-rc.3",
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "good-vibe",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "description": "AI 팀을 구성하고 프로젝트를 관리하세요. CEO가 되어 가상 AI 팀원들과 기획부터 실행까지.",
   "author": {
     "name": "sumsun-dev",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 
 ## [Unreleased]
 
+## [2.0.0-rc.3] - 2026-04-28
+
+> **RC 3** — Unprefixed 슬래시 단축어 설치 기능 추가. 사용자가 `/good-vibe:install-shortcuts` 한 번 실행하면 `/gv`, `/gv-status` 등을 네임스페이스 없이 호출 가능. ECC/OMC/claude-forge 가 검증한 `install.sh` 패턴.
+
+### Added
+
+- **`/good-vibe:install-shortcuts` 슬래시** — `~/.claude/commands/` 에 7개 단축어 래퍼(`gv`, `gv-status`, `gv-execute`, `gv-resume`, `gv-team`, `gv-cost`, `gv-agent-history`)를 한 번에 설치. 멱등성 보장, `--force` 덮어쓰기 옵션
+- **`uninstall-shortcuts` CLI** — 우리가 설치한 파일만 안전하게 제거. 서명 없는 사용자 직접 작성 파일은 보존
+- **`scripts/lib/core/shortcuts-installer.js`** — `WRAPPER_SIGNATURE` 기반 래퍼 정의 + install/uninstall 코어 로직
+- **README 단축어 설치 섹션** — 사용법 + 멱등성 + 충돌 처리 명시
+
+### Why
+
+- Claude Code 플러그인은 `{plugin}:{cmd}` 네임스페이스가 강제됨 → `/good-vibe:gv` 매번 길게 입력
+- 유저 스코프 `~/.claude/commands/` 에 직접 배치된 커맨드는 prefix 없이 호출 가능 → 단축어 래퍼로 우회
+- 다른 인기 프로젝트(everything-claude-code 168K⭐, oh-my-claudecode 31K⭐, claude-forge 668⭐) 모두 동일 패턴 채택
+
 ## [2.0.0-rc.2] - 2026-04-28
 
 > **RC 2** — 자가발전(self-evolution) 시스템 완성. 학습 루프 + 회귀 안전망 + CEO 가시성/제어가 모두 갖춰진 1단계 완료. v2.0.0 정식 승급은 도그푸딩 후 결정.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,27 @@ npm install
 /plugin marketplace update good-vibe
 ```
 
+### 단축어 설치 (선택, 권장)
+
+플러그인은 Claude Code 규약상 `/good-vibe:gv` 처럼 네임스페이스가 강제됩니다. 한 번 실행하면 `/gv`, `/gv-status` 등 짧은 형태로 호출할 수 있습니다.
+
+```bash
+/good-vibe:install-shortcuts
+```
+
+설치 후 사용:
+
+```
+/gv 트위터 봇 만들고 싶어
+/gv-status
+/gv-execute auto
+```
+
+- 멱등성: 여러 번 실행해도 안전 (이미 설치된 항목은 skip)
+- `--force`: 기존 파일 덮어쓰기
+- `/good-vibe:uninstall-shortcuts`: 우리가 설치한 파일만 제거 (사용자 직접 만든 동명 파일은 보존)
+- 설치 위치: `~/.claude/commands/gv*.md` (사용자 스코프)
+
 ### 필요한 것
 
 - [Claude Code](https://claude.ai/code) 2.0 이상

--- a/commands/install-shortcuts.md
+++ b/commands/install-shortcuts.md
@@ -1,0 +1,70 @@
+---
+description: 'Good Vibe 단축어(`/gv`, `/gv-status` 등) 설치 — 사용자 스코프 래퍼를 한 번에 작성'
+argument-hint: '[--force | --uninstall]'
+---
+
+# /gv:install-shortcuts — 단축어 한 번에 설치
+
+플러그인은 `/good-vibe:gv` 처럼 네임스페이스가 강제됩니다. 이 명령은 `~/.claude/commands/` 에 7개 thin 래퍼를 작성해 `/gv`, `/gv-status` 등 짧은 형태로 호출 가능하게 만듭니다.
+
+- **소요시간:** 즉시 (1초 이내)
+- **결과물:** 7개 래퍼 파일 + 설치/충돌/skip 보고
+- **멱등성:** 두 번 실행해도 안전 (이미 설치된 항목은 skip)
+
+## 인자
+
+- 없음: 기본 설치 (멱등)
+- `--force`: 기존 동명 파일을 덮어씀 (사용자 파일 포함 — 주의)
+- `--uninstall`: 우리가 설치한 파일만 제거 (서명 없는 사용자 파일은 보존)
+
+## 실행 흐름
+
+### Step 1: 사용자 의도 파악
+
+`$ARGUMENTS` 를 검사하여 다음 분기:
+
+- `--uninstall` 포함 → uninstall 경로
+- `--force` 포함 → install with force
+- 그 외 → 기본 install
+
+### Step 2: 단순 CLI 1회 호출 (Thin Controller)
+
+**Install:**
+
+```bash
+echo '{"force": <bool>}' | node "${CLAUDE_PLUGIN_ROOT}/scripts/cli.js" install-shortcuts
+```
+
+**Uninstall:**
+
+```bash
+echo '{}' | node "${CLAUDE_PLUGIN_ROOT}/scripts/cli.js" uninstall-shortcuts
+```
+
+### Step 3: 결과 표시
+
+핸들러 응답 (`installed`, `skipped`, 또는 `removed`, `preserved`)을 그대로 표시:
+
+- `installed` 항목 → "✅ 설치됨" 목록
+- `skipped` 중 `reason: "already-installed"` → "⏭ 이미 설치됨"
+- `skipped` 중 `reason: "conflict"` → "⚠️ 충돌 (사용자 파일 보존, `--force` 로 덮어쓰기 가능)"
+- `removed` → "🗑 제거됨"
+- `preserved` → "🔒 보존됨 (사용자 파일)"
+
+이후 사용자에게 `/gv`, `/gv-status` 등을 바로 사용 가능함을 안내.
+
+## 사용 예시
+
+```
+/good-vibe:install-shortcuts
+/good-vibe:install-shortcuts --force
+/good-vibe:install-shortcuts --uninstall
+```
+
+설치 후:
+
+```
+/gv 트위터 봇 만들고 싶어
+/gv-status
+/gv-execute auto
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "good-vibe",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "description": "AI 팀을 구성하여 프로젝트를 기획-토론-실행-리뷰하는 멀티에이전트 플랫폼",
   "type": "module",
   "types": "types/index.d.ts",

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -170,6 +170,8 @@ const COMMAND_MAP = {
   'generate-global-onboarding': 'infra',
   'write-global-onboarding': 'infra',
   'write-project-onboarding': 'infra',
+  'install-shortcuts': 'infra',
+  'uninstall-shortcuts': 'infra',
   // metrics
   'record-metrics': 'metrics',
   'project-metrics': 'metrics',

--- a/scripts/handlers/infra.js
+++ b/scripts/handlers/infra.js
@@ -1,7 +1,7 @@
 /**
  * handlers/infra — 프로젝트 인프라 셋업 + GitHub + 온보딩 + 설정 커맨드
  */
-import { readStdin, output } from '../cli-utils.js';
+import { readStdin, output, outputOk } from '../cli-utils.js';
 import {
   requireFields,
   requireArray,
@@ -42,6 +42,7 @@ import {
 import { loadPreset, mergePresets } from '../lib/core/preset-loader.js';
 import { safeWriteFile, ensureDir } from '../lib/core/file-writer.js';
 import { claudeDir } from '../lib/core/app-paths.js';
+import { installShortcuts, uninstallShortcuts } from '../lib/core/shortcuts-installer.js';
 import { resolve } from 'path';
 import { homedir } from 'os';
 
@@ -268,5 +269,24 @@ export const commands = {
       safeWriteFile(coreRulesPath, data.coreRules, { overwrite: true }),
     ]);
     output({ written: [claudeMdPath, coreRulesPath] });
+  },
+
+  'install-shortcuts': async () => {
+    const data = await readStdin();
+    const targetDir = data.targetDir ? resolve(data.targetDir) : resolve(claudeDir(), 'commands');
+    if (data.targetDir) assertWithinRoot(targetDir, homedir(), 'targetDir');
+    const result = await installShortcuts({
+      targetDir,
+      force: Boolean(data.force),
+    });
+    outputOk(result);
+  },
+
+  'uninstall-shortcuts': async () => {
+    const data = await readStdin();
+    const targetDir = data.targetDir ? resolve(data.targetDir) : resolve(claudeDir(), 'commands');
+    if (data.targetDir) assertWithinRoot(targetDir, homedir(), 'targetDir');
+    const result = await uninstallShortcuts({ targetDir });
+    outputOk(result);
   },
 };

--- a/scripts/lib/core/shortcuts-installer.js
+++ b/scripts/lib/core/shortcuts-installer.js
@@ -1,0 +1,195 @@
+/**
+ * shortcuts-installer — 사용자 스코프(~/.claude/commands/)에 unprefixed 단축어 래퍼를 설치/제거.
+ *
+ * Claude Code 플러그인은 `{plugin}:{cmd}` 네임스페이스가 강제되어 `/good-vibe:gv` 형태로만 호출 가능.
+ * 이 모듈은 사용자 폴더에 thin 래퍼 .md 파일을 작성해 `/gv` 같은 네임스페이스 없는 호출을 가능하게 함.
+ * 모든 래퍼는 WRAPPER_SIGNATURE 코멘트를 포함 → uninstall 시 우리가 설치한 파일만 안전하게 제거.
+ */
+
+import { readFile, writeFile, unlink, readdir } from 'fs/promises';
+import { resolve } from 'path';
+import { ensureDir, fileExists } from './file-writer.js';
+import { AppError } from './validators.js';
+
+function escapeYamlDouble(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function wrapFsError(err, action) {
+  if (err && err.code === 'EACCES') {
+    return new AppError(
+      `${action} 권한이 없습니다: ${err.path || err.message}`,
+      'PERMISSION_ERROR',
+    );
+  }
+  if (err && err.code === 'EROFS') {
+    return new AppError(
+      `${action} 대상이 읽기 전용입니다: ${err.path || err.message}`,
+      'PERMISSION_ERROR',
+    );
+  }
+  return err;
+}
+
+/** 우리가 작성한 래퍼임을 식별하는 서명 (uninstall 안전성) */
+export const WRAPPER_SIGNATURE = '<!-- good-vibe:shortcut-wrapper -->';
+
+/** Good Vibe 단축어 정의 — 7개 진입점 */
+export const SHORTCUT_DEFINITIONS = [
+  {
+    name: 'gv',
+    targetSkill: 'good-vibe:gv',
+    description: 'Good Vibe NL 진입점 — 자연어 한 줄로 의도 분류',
+    argumentHint: '<자연어 한 줄>',
+  },
+  {
+    name: 'gv-status',
+    targetSkill: 'good-vibe:gv-status',
+    description: 'Good Vibe 상태/진행 조회',
+  },
+  {
+    name: 'gv-execute',
+    targetSkill: 'good-vibe:gv-execute',
+    description: 'Good Vibe 실행 시작 — task-graph 진입점',
+    argumentHint: '[interactive|semi-auto|auto]',
+  },
+  {
+    name: 'gv-resume',
+    targetSkill: 'good-vibe:gv-resume',
+    description: 'Good Vibe 중단 작업 재개',
+  },
+  {
+    name: 'gv-team',
+    targetSkill: 'good-vibe:gv-team',
+    description: 'Good Vibe 팀 구성 보기/편집',
+  },
+  {
+    name: 'gv-cost',
+    targetSkill: 'good-vibe:gv-cost',
+    description: 'Good Vibe 비용/예산 임계 조회·설정',
+    argumentHint: '[budget setting]',
+  },
+  {
+    name: 'gv-agent-history',
+    targetSkill: 'good-vibe:gv-agent-history',
+    description: 'Good Vibe 에이전트 자가발전 학습 이력 + revert',
+    argumentHint: '[revert]',
+  },
+];
+
+/**
+ * 단축어 정의로 슬래시 커맨드 .md 파일 본문을 생성한다.
+ * @param {object} def - 단축어 정의 (name, targetSkill, description, argumentHint?)
+ * @returns {string} 마크다운 본문
+ */
+export function buildWrapperContent(def) {
+  const frontmatterLines = ['---', `description: "${escapeYamlDouble(def.description)}"`];
+  if (def.argumentHint) {
+    frontmatterLines.push(`argument-hint: "${escapeYamlDouble(def.argumentHint)}"`);
+  }
+  frontmatterLines.push('---');
+
+  const argsLine = def.argumentHint ? ` with these arguments: $ARGUMENTS` : '.';
+
+  return [
+    ...frontmatterLines,
+    '',
+    WRAPPER_SIGNATURE,
+    '',
+    `Use the Skill tool to invoke \`${def.targetSkill}\`${argsLine}`,
+    '',
+    'This is a thin wrapper installed by `good-vibe:install-shortcuts`. To remove,',
+    'run `good-vibe:uninstall-shortcuts` (or delete this file manually).',
+    '',
+  ].join('\n');
+}
+
+async function classifyExisting(filePath) {
+  if (!(await fileExists(filePath))) return 'absent';
+  const content = await readFile(filePath, 'utf-8');
+  return content.includes(WRAPPER_SIGNATURE) ? 'owned' : 'foreign';
+}
+
+/**
+ * 사용자 스코프에 단축어 래퍼 7개를 설치한다.
+ * @param {object} options
+ * @param {string} options.targetDir - 설치 대상 디렉토리 (~/.claude/commands)
+ * @param {boolean} [options.force=false] - 기존 파일 덮어쓰기 (서명 있는 파일만)
+ * @returns {Promise<{installed: Array, skipped: Array, targetDir: string}>}
+ */
+export async function installShortcuts({ targetDir, force = false }) {
+  try {
+    await ensureDir(targetDir);
+  } catch (err) {
+    throw wrapFsError(err, '단축어 디렉토리 생성');
+  }
+
+  const installed = [];
+  const skipped = [];
+
+  for (const def of SHORTCUT_DEFINITIONS) {
+    const filePath = resolve(targetDir, `${def.name}.md`);
+    const status = await classifyExisting(filePath);
+
+    if (status === 'foreign' && !force) {
+      skipped.push({ name: def.name, reason: 'conflict', path: filePath });
+      continue;
+    }
+
+    if (status === 'owned' && !force) {
+      skipped.push({ name: def.name, reason: 'already-installed', path: filePath });
+      continue;
+    }
+
+    try {
+      await writeFile(filePath, buildWrapperContent(def), 'utf-8');
+    } catch (err) {
+      throw wrapFsError(err, `${def.name}.md 쓰기`);
+    }
+    installed.push({ name: def.name, path: filePath });
+  }
+
+  return { installed, skipped, targetDir };
+}
+
+/**
+ * 사용자 스코프에서 우리가 설치한 단축어를 제거한다.
+ * 서명이 없는 동명 파일은 사용자 소유로 간주하여 보존한다.
+ * @param {object} options
+ * @param {string} options.targetDir - 대상 디렉토리
+ * @returns {Promise<{removed: Array, preserved: Array, targetDir: string}>}
+ */
+export async function uninstallShortcuts({ targetDir }) {
+  const removed = [];
+  const preserved = [];
+
+  let exists = true;
+  try {
+    await readdir(targetDir);
+  } catch (err) {
+    if (err.code === 'ENOENT') exists = false;
+    else throw err;
+  }
+
+  if (!exists) return { removed, preserved, targetDir };
+
+  for (const def of SHORTCUT_DEFINITIONS) {
+    const filePath = resolve(targetDir, `${def.name}.md`);
+    const status = await classifyExisting(filePath);
+
+    if (status === 'absent') continue;
+    if (status === 'foreign') {
+      preserved.push({ name: def.name, reason: 'not-owned', path: filePath });
+      continue;
+    }
+
+    try {
+      await unlink(filePath);
+    } catch (err) {
+      throw wrapFsError(err, `${def.name}.md 삭제`);
+    }
+    removed.push({ name: def.name, path: filePath });
+  }
+
+  return { removed, preserved, targetDir };
+}

--- a/tests/handlers/shortcuts.test.js
+++ b/tests/handlers/shortcuts.test.js
@@ -1,0 +1,99 @@
+/**
+ * install-shortcuts / uninstall-shortcuts 핸들러 E2E 테스트.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdir, rm, readFile, writeFile, readdir } from 'fs/promises';
+import { resolve } from 'path';
+
+const CLI_PATH = resolve('scripts/cli.js');
+const TMP_DIR = resolve('.tmp-test-shortcuts-handler');
+const TARGET_DIR = resolve(TMP_DIR, 'commands');
+
+beforeEach(async () => {
+  await rm(TMP_DIR, { recursive: true, force: true });
+  await mkdir(TMP_DIR, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(TMP_DIR, { recursive: true, force: true });
+});
+
+function exec(command, input) {
+  return JSON.parse(
+    execSync(`node ${CLI_PATH} ${command}`, {
+      input: input !== undefined ? JSON.stringify(input) : '',
+      encoding: 'utf-8',
+      timeout: 10_000,
+    }),
+  );
+}
+
+function execRaw(command, input) {
+  try {
+    const stdout = execSync(`node ${CLI_PATH} ${command}`, {
+      input: input !== undefined ? JSON.stringify(input) : '',
+      encoding: 'utf-8',
+      timeout: 10_000,
+    });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (err) {
+    return { exitCode: err.status, stdout: '', stderr: err.stderr || '' };
+  }
+}
+
+describe('handlers/infra — install-shortcuts E2E', () => {
+  it('targetDir 지정 시 7개 파일을 작성하고 success 응답', async () => {
+    const r = exec('install-shortcuts', { targetDir: TARGET_DIR });
+    expect(r.success).toBe(true);
+    expect(r.installed).toHaveLength(7);
+    expect(r.skipped).toHaveLength(0);
+    const files = await readdir(TARGET_DIR);
+    expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(7);
+  });
+
+  it('각 래퍼는 description, targetSkill, $ARGUMENTS 포함', async () => {
+    exec('install-shortcuts', { targetDir: TARGET_DIR });
+    const gv = await readFile(resolve(TARGET_DIR, 'gv.md'), 'utf-8');
+    expect(gv).toContain('good-vibe:gv');
+    expect(gv).toContain('$ARGUMENTS');
+    expect(gv).toContain('description:');
+  });
+
+  it('두 번째 호출은 멱등 (모두 skip)', async () => {
+    exec('install-shortcuts', { targetDir: TARGET_DIR });
+    const r2 = exec('install-shortcuts', { targetDir: TARGET_DIR });
+    expect(r2.installed).toHaveLength(0);
+    expect(r2.skipped).toHaveLength(7);
+    expect(r2.skipped[0].reason).toBe('already-installed');
+  });
+
+  it('force=true 면 덮어쓰기', async () => {
+    exec('install-shortcuts', { targetDir: TARGET_DIR });
+    await writeFile(resolve(TARGET_DIR, 'gv.md'), 'tampered', 'utf-8');
+    const r = exec('install-shortcuts', { targetDir: TARGET_DIR, force: true });
+    expect(r.installed).toHaveLength(7);
+    const content = await readFile(resolve(TARGET_DIR, 'gv.md'), 'utf-8');
+    expect(content).toContain('good-vibe:gv');
+  });
+
+  it('targetDir이 homedir() 바깥이면 INPUT_ERROR (path traversal 차단)', () => {
+    const r = execRaw('install-shortcuts', { targetDir: '/etc/foo' });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/targetDir/);
+  });
+
+  it('uninstall-shortcuts → 우리가 설치한 파일만 제거', async () => {
+    exec('install-shortcuts', { targetDir: TARGET_DIR });
+    await writeFile(resolve(TARGET_DIR, 'gv-status.md'), '# user override', 'utf-8');
+    const r = exec('uninstall-shortcuts', { targetDir: TARGET_DIR });
+    expect(r.success).toBe(true);
+    expect(r.removed.length).toBeGreaterThan(0);
+    expect(r.preserved).toContainEqual(
+      expect.objectContaining({ name: 'gv-status', reason: 'not-owned' }),
+    );
+    const userFile = await readFile(resolve(TARGET_DIR, 'gv-status.md'), 'utf-8');
+    expect(userFile).toBe('# user override');
+  });
+});

--- a/tests/shortcuts-installer.test.js
+++ b/tests/shortcuts-installer.test.js
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, readFile, writeFile, readdir } from 'fs/promises';
+import { resolve } from 'path';
+import {
+  SHORTCUT_DEFINITIONS,
+  buildWrapperContent,
+  installShortcuts,
+  uninstallShortcuts,
+  WRAPPER_SIGNATURE,
+} from '../scripts/lib/core/shortcuts-installer.js';
+
+const TMP_DIR = resolve('.tmp-test-shortcuts');
+
+describe('shortcuts-installer', () => {
+  beforeEach(async () => {
+    await mkdir(TMP_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(TMP_DIR, { recursive: true, force: true });
+  });
+
+  describe('SHORTCUT_DEFINITIONS', () => {
+    it('7개 단축어를 정의해야 한다', () => {
+      expect(SHORTCUT_DEFINITIONS).toHaveLength(7);
+    });
+
+    it('각 단축어는 name, targetSkill, description 필드를 가져야 한다', () => {
+      for (const def of SHORTCUT_DEFINITIONS) {
+        expect(def).toHaveProperty('name');
+        expect(def).toHaveProperty('targetSkill');
+        expect(def).toHaveProperty('description');
+        expect(def.targetSkill).toMatch(/^good-vibe:/);
+      }
+    });
+
+    it('필수 단축어를 모두 포함해야 한다', () => {
+      const names = SHORTCUT_DEFINITIONS.map((d) => d.name);
+      expect(names).toEqual(
+        expect.arrayContaining([
+          'gv',
+          'gv-status',
+          'gv-execute',
+          'gv-resume',
+          'gv-team',
+          'gv-cost',
+          'gv-agent-history',
+        ]),
+      );
+    });
+  });
+
+  describe('buildWrapperContent', () => {
+    it('description과 targetSkill을 포함한 마크다운을 생성해야 한다', () => {
+      const def = {
+        name: 'gv',
+        targetSkill: 'good-vibe:gv',
+        description: 'NL 진입점',
+        argumentHint: '<자연어>',
+      };
+      const content = buildWrapperContent(def);
+      expect(content).toContain('description: "NL 진입점"');
+      expect(content).toContain('argument-hint: "<자연어>"');
+      expect(content).toContain('good-vibe:gv');
+      expect(content).toContain('$ARGUMENTS');
+    });
+
+    it('argumentHint가 없으면 frontmatter에서 생략되어야 한다', () => {
+      const def = {
+        name: 'gv-status',
+        targetSkill: 'good-vibe:gv-status',
+        description: '상태 조회',
+      };
+      const content = buildWrapperContent(def);
+      expect(content).not.toContain('argument-hint');
+      expect(content).toContain('good-vibe:gv-status');
+    });
+
+    it('서명(WRAPPER_SIGNATURE)을 포함해야 한다 (uninstall 식별용)', () => {
+      const def = SHORTCUT_DEFINITIONS[0];
+      const content = buildWrapperContent(def);
+      expect(content).toContain(WRAPPER_SIGNATURE);
+    });
+
+    it('description 안의 큰따옴표/백슬래시를 이스케이프해야 한다 (YAML 안전성)', () => {
+      const def = {
+        name: 'evil',
+        targetSkill: 'good-vibe:evil',
+        description: 'has " quote and \\ slash',
+      };
+      const content = buildWrapperContent(def);
+      expect(content).toContain('description: "has \\" quote and \\\\ slash"');
+    });
+  });
+
+  describe('installShortcuts', () => {
+    it('지정 디렉토리에 7개 파일을 작성해야 한다', async () => {
+      const result = await installShortcuts({ targetDir: TMP_DIR });
+      expect(result.installed).toHaveLength(7);
+      expect(result.skipped).toHaveLength(0);
+      const files = await readdir(TMP_DIR);
+      expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(7);
+    });
+
+    it('targetDir이 없으면 자동 생성해야 한다', async () => {
+      const nestedDir = resolve(TMP_DIR, 'nested', 'commands');
+      await installShortcuts({ targetDir: nestedDir });
+      const files = await readdir(nestedDir);
+      expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(7);
+    });
+
+    it('이미 같은 단축어가 존재하면 skip 한다 (멱등성)', async () => {
+      await installShortcuts({ targetDir: TMP_DIR });
+      const result = await installShortcuts({ targetDir: TMP_DIR });
+      expect(result.installed).toHaveLength(0);
+      expect(result.skipped).toHaveLength(7);
+    });
+
+    it('force=true 면 기존 파일을 덮어쓴다', async () => {
+      await installShortcuts({ targetDir: TMP_DIR });
+      const filePath = resolve(TMP_DIR, 'gv.md');
+      await writeFile(filePath, 'modified', 'utf-8');
+      const result = await installShortcuts({ targetDir: TMP_DIR, force: true });
+      expect(result.installed).toHaveLength(7);
+      const content = await readFile(filePath, 'utf-8');
+      expect(content).toContain('good-vibe:gv');
+    });
+
+    it('우리 서명 없는 동명 파일은 force 없이 skip + 충돌 보고', async () => {
+      const filePath = resolve(TMP_DIR, 'gv.md');
+      await mkdir(TMP_DIR, { recursive: true });
+      await writeFile(filePath, '# 사용자가 직접 만든 파일', 'utf-8');
+      const result = await installShortcuts({ targetDir: TMP_DIR });
+      expect(result.skipped).toContainEqual(
+        expect.objectContaining({ name: 'gv', reason: 'conflict' }),
+      );
+      expect(result.installed.length).toBeLessThan(7);
+    });
+  });
+
+  describe('uninstallShortcuts', () => {
+    it('우리가 설치한 7개 파일만 제거한다', async () => {
+      await installShortcuts({ targetDir: TMP_DIR });
+      const result = await uninstallShortcuts({ targetDir: TMP_DIR });
+      expect(result.removed).toHaveLength(7);
+      const files = await readdir(TMP_DIR);
+      expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(0);
+    });
+
+    it('서명 없는 동명 파일은 보존한다', async () => {
+      const filePath = resolve(TMP_DIR, 'gv.md');
+      await writeFile(filePath, '# 사용자 파일', 'utf-8');
+      const result = await uninstallShortcuts({ targetDir: TMP_DIR });
+      expect(result.removed).toHaveLength(0);
+      expect(result.preserved).toContainEqual(
+        expect.objectContaining({ name: 'gv', reason: 'not-owned' }),
+      );
+      const content = await readFile(filePath, 'utf-8');
+      expect(content).toBe('# 사용자 파일');
+    });
+
+    it('파일이 존재하지 않으면 무시한다', async () => {
+      const result = await uninstallShortcuts({ targetDir: TMP_DIR });
+      expect(result.removed).toHaveLength(0);
+      expect(result.preserved).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `/good-vibe:install-shortcuts` 슬래시 추가 — `~/.claude/commands/` 에 7개 thin 래퍼 설치 (`gv`, `gv-status`, `gv-execute`, `gv-resume`, `gv-team`, `gv-cost`, `gv-agent-history`)
- 사용자가 한 번 실행하면 `/gv` 처럼 네임스페이스 없는 짧은 호출 가능 → 공유 가능한 패턴
- `uninstall-shortcuts` CLI — 서명 기반 ownership 판정으로 사용자 직접 작성 동명 파일 보존

## Why

Claude Code 플러그인은 `{plugin}:{cmd}` 네임스페이스가 강제되어 매번 `/good-vibe:gv` 처럼 길게 호출해야 함. 인기 프로젝트들(everything-claude-code 168K⭐, oh-my-claudecode 31K⭐, claude-forge 668⭐)이 모두 동일한 한계를 만났고 모두 `install.sh` 패턴으로 해결. 본 PR은 동일 패턴을 Good Vibe 에 적용.

## 핵심 설계

- **WRAPPER_SIGNATURE** (`<!-- good-vibe:shortcut-wrapper -->`) — 우리가 설치한 파일 식별 → uninstall 시 사용자 파일 보존
- **멱등성** — 두 번 실행해도 안전 (이미 설치된 항목 skip)
- **`--force`** — 기존 파일 덮어쓰기 (foreign 포함)
- **path traversal 차단** — `assertWithinRoot(targetDir, homedir())`
- **EACCES/EROFS** → `AppError(PERMISSION_ERROR)` 래핑
- **YAML 이스케이프** — description/argumentHint 의 `"`, `\` 안전 처리

## 변경 파일

신규:
- `scripts/lib/core/shortcuts-installer.js` — 코어 (정의 + install/uninstall + 에러 래핑)
- `commands/install-shortcuts.md` — 슬래시 커맨드 스펙
- `tests/shortcuts-installer.test.js` — 15 unit 테스트
- `tests/handlers/shortcuts.test.js` — 6 E2E 테스트 (path traversal 회귀 포함)

수정:
- `scripts/handlers/infra.js` — `install-shortcuts`, `uninstall-shortcuts` 핸들러
- `scripts/cli.js` — COMMAND_MAP 등록
- `README.md` — "단축어 설치 (선택, 권장)" 섹션 추가
- `CHANGELOG.md` — 2.0.0-rc.3 엔트리
- `package.json` / `plugin.json` / `marketplace.json` — version bump

## Test plan

- [x] `npx vitest run tests/shortcuts-installer.test.js tests/handlers/shortcuts.test.js` — 21/21 통과
- [x] `npm test` — 3062/3062 (2 skipped, 사전 존재) 통과
- [x] `npm run lint` — clean
- [x] code-reviewer-kr 리뷰: Critical 0, Warning 2 (수정 완료), Suggestion 2 (1건 반영)
- [ ] 머지 후 플러그인 캐시 갱신 → `/good-vibe:install-shortcuts` 동작 확인
- [ ] 동일 사용자 환경에서 `/gv-status` 정상 호출 확인
- [ ] `/good-vibe:uninstall-shortcuts` 으로 정리 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)