### PR TITLE
feat(gv-init): 신규 프로젝트 통합 셋업 — 폴더 + (선택)GitHub + Good Vibe 엔트리

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "AI 팀을 구성하여 프로젝트를 기획-토론-실행-리뷰하는 멀티에이전트 플랫폼",
-    "version": "2.0.0-rc.3"
+    "version": "2.0.0-rc.4"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "url": "https://github.com/sumsun-dev/good-vibe-coding.git"
       },
       "description": "AI 팀을 구성하고 프로젝트를 관리하세요. CEO가 되어 가상 AI 팀원들과 기획부터 실행까지.",
-      "version": "2.0.0-rc.3",
+      "version": "2.0.0-rc.4",
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "good-vibe",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0-rc.4",
   "description": "AI 팀을 구성하고 프로젝트를 관리하세요. CEO가 되어 가상 AI 팀원들과 기획부터 실행까지.",
   "author": {
     "name": "sumsun-dev",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 
 ## [Unreleased]
 
+## [2.0.0-rc.4] - 2026-04-28
+
+> **RC 4** — `/gv-init` 신규 프로젝트 통합 셋업. 폴더 scaffold + (선택) GitHub repo + Good Vibe 프로젝트 엔트리를 한 번에 만듬. `gh auth status` 기반 자동 옵션 분기.
+
+### Added
+
+- **`/gv-init` 슬래시** — AskUserQuestion 으로 이름/폴더/GitHub 옵션 수집 → `init-project` CLI 1회 호출 → 결과 표시. `commands/gv-init.md`
+- **`init-project` CLI** — `setupProjectInfra` + (선택) `createGithubRepo` + `gitInitAndPush` + `createProject` 를 묶은 통합 진입점. 부분 실패 시 `warnings` 배열에 사유 기록, 로컬 프로젝트는 유지
+- **`slugify-name` CLI** — 한글/특수문자 제거 + 하이픈 정규화. AskUserQuestion 기본값 계산용
+- **`scripts/lib/project/project-initializer.js`** — `initProject()` + `slugifyName()` 코어
+- **`gv-dispatch` 응답 확장** — `needsProjectSetup: boolean` 플래그. `code` task + `hasProject=false` + non-escalate 일 때 true. `nextActions` 에 `/gv-init` 안내 자동 포함
+- **단축어 추가** — `gv-init` (총 8개). `shortcuts-installer` `SHORTCUT_DEFINITIONS` 갱신
+
+### Why
+
+- 신규 프로젝트는 폴더/repo 셋업이 `/gv-execute` 진입 전에 필요. 기존 흐름은 사용자가 수동 `mkdir` + `gh repo create` + `setup-project-infra` 를 따로 호출해야 했음
+- gh 인증 상태에 따라 선택지가 달라야 자연스러움 (인증 안되면 GitHub 옵션 자체를 보여주지 않음)
+- 부분 실패(repo 이름 충돌, push 실패) 시 로컬 프로젝트는 유지해야 작업 손실 없음
+
 ## [2.0.0-rc.3] - 2026-04-28
 
 > **RC 3** — Unprefixed 슬래시 단축어 설치 기능 추가. 사용자가 `/good-vibe:install-shortcuts` 한 번 실행하면 `/gv`, `/gv-status` 등을 네임스페이스 없이 호출 가능. ECC/OMC/claude-forge 가 검증한 `install.sh` 패턴.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ npm install
 
 ```
 /gv 트위터 봇 만들고 싶어
+/gv-init                    # 폴더 + (선택) GitHub repo 셋업
 /gv-status
 /gv-execute auto
 ```
@@ -82,6 +83,7 @@ npm install
 - `--force`: 기존 파일 덮어쓰기
 - `/good-vibe:uninstall-shortcuts`: 우리가 설치한 파일만 제거 (사용자 직접 만든 동명 파일은 보존)
 - 설치 위치: `~/.claude/commands/gv*.md` (사용자 스코프)
+- 신규 프로젝트는 `/gv-init` 으로 폴더/repo 셋업 → `/gv-execute` 로 task-graph 진입 (gh 인증 상태에 따라 GitHub repo 옵션 자동 분기)
 
 ### 필요한 것
 

--- a/commands/gv-init.md
+++ b/commands/gv-init.md
@@ -1,0 +1,98 @@
+---
+description: '신규 프로젝트 셋업 — 폴더 + (선택) GitHub repo + Good Vibe 프로젝트 엔트리'
+argument-hint: '[프로젝트 이름]'
+---
+
+# /gv-init — 신규 프로젝트 셋업
+
+폴더 scaffold + (선택) GitHub repo 생성 + Good Vibe 프로젝트 엔트리를 한 번에 만듭니다. `/gv-execute` 진입 전에 한 번 실행하세요.
+
+- **소요시간:** 5–20초 (GitHub repo 만들면 +5초)
+- **결과물:** `~/projects/{slug}/` 폴더 + 초기 scaffold + (선택) GitHub repo + Good Vibe 프로젝트 엔트리
+- **다음 단계:** `/gv-execute auto` 로 task-graph 진입
+
+## 실행 흐름
+
+### Step 1: 사용자 입력 수집 (AskUserQuestion)
+
+**1-1. 프로젝트 이름**
+
+`$ARGUMENTS` 가 비어 있으면 AskUserQuestion 으로 묻고, 있으면 그 값을 기본값으로 사용.
+
+**1-2. 폴더 위치**
+
+기본값: `~/projects/{slug}` (slug 는 이름에서 자동 변환)
+
+```bash
+echo '{"name": "<입력 이름>"}' | node "${CLAUDE_PLUGIN_ROOT}/scripts/cli.js" slugify-name
+```
+
+응답: `{"slug": "..."}`. 그걸로 기본 경로 제시. 사용자 수정 허용.
+
+**1-3. GitHub repo 옵션 — gh 인증 상태에 따라 분기**
+
+먼저 인증 상태 확인:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/cli.js" check-gh-status
+```
+
+응답: `{"installed": bool, "authenticated": bool, "username": "..."}`.
+
+- `authenticated: true` → AskUserQuestion 선택지: `["비공개 (private)", "공개 (public)", "건너뛰기 (로컬만)"]`
+- `installed: false` → AskUserQuestion: `["건너뛰기 (gh CLI 미설치)", "취소 (먼저 gh 설치 후 재실행)"]`
+- `installed: true && authenticated: false` → AskUserQuestion: `["건너뛰기 (gh 미인증)", "취소 (먼저 gh auth login 후 재실행)"]`
+
+매핑:
+
+- "비공개" → `github: "private"`
+- "공개" → `github: "public"`
+- "건너뛰기" → `github: "none"`
+- "취소" → 흐름 중단, 사용자 안내
+
+**1-4. (선택) 프로젝트 유형**
+
+기본값 `cli-tool`. AskUserQuestion 생략 가능 (모르면 `cli-tool` 기본값으로 진행).
+
+### Step 2: init-project CLI 호출 (Thin Controller)
+
+```bash
+echo '{
+  "name": "<이름>",
+  "type": "<유형>",
+  "description": "<설명>",
+  "targetDir": "<절대 경로>",
+  "github": "private | public | none",
+  "techStack": "<선택>",
+  "mode": "<plan-only | plan-execute | quick-build, 선택>"
+}' | node "${CLAUDE_PLUGIN_ROOT}/scripts/cli.js" init-project
+```
+
+응답:
+
+```json
+{
+  "success": true,
+  "projectId": "...",
+  "project": { "id": "...", "name": "...", "status": "planning" },
+  "infraPath": "/path/to/folder",
+  "githubUrl": "https://github.com/me/slug" | null,
+  "files": [...],
+  "ci": null | {...},
+  "warnings": []
+}
+```
+
+### Step 3: 결과 표시
+
+CEO에게:
+
+1. ✅ **셋업 완료** + `infraPath`, `githubUrl` (있으면), 생성된 파일 수
+2. ⚠️ **`warnings` 배열이 비어있지 않으면** 각 항목 표시 (예: GitHub repo 이미 존재, push 실패 등). 그래도 로컬 프로젝트는 정상 생성됨을 안내
+3. **다음 액션:** `/gv-execute auto` 로 task-graph 시작 (또는 `/gv-execute interactive` 로 단계별 확인)
+
+## 메인 세션 원칙
+
+- AskUserQuestion 으로 사용자 입력 수집만
+- check-gh-status, slugify-name, init-project — 단순 CLI 호출만 (LLM 없음)
+- 데이터 가공/추가 분석 금지

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "good-vibe",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0-rc.4",
   "description": "AI 팀을 구성하여 프로젝트를 기획-토론-실행-리뷰하는 멀티에이전트 플랫폼",
   "type": "module",
   "types": "types/index.d.ts",

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -172,6 +172,8 @@ const COMMAND_MAP = {
   'write-project-onboarding': 'infra',
   'install-shortcuts': 'infra',
   'uninstall-shortcuts': 'infra',
+  'init-project': 'infra',
+  'slugify-name': 'infra',
   // metrics
   'record-metrics': 'metrics',
   'project-metrics': 'metrics',

--- a/scripts/handlers/dispatch.js
+++ b/scripts/handlers/dispatch.js
@@ -30,10 +30,17 @@ export const commands = {
       result = { category: 'task', taskRoute: routeTask(input, { hasGitRepo }) };
     }
 
+    const needsProjectSetup =
+      result.category === 'task' &&
+      (result.taskRoute?.taskType === 'code' || result.taskRoute?.taskType === 'plan') &&
+      !hasProject &&
+      !result.taskRoute?.escalateForConfirm;
+
     output({
       category: result.category,
       taskRoute: result.taskRoute || null,
-      nextActions: buildNextActions(result, { hasProject }),
+      needsProjectSetup,
+      nextActions: buildNextActions(result, { hasProject, needsProjectSetup }),
     });
   },
 };
@@ -49,13 +56,13 @@ function buildNextActions(result, ctx) {
         ? ['/gv 수정 요청을 자연어로 입력하면 task로 라우팅됩니다 (예: "이 함수 리팩토링해줘")']
         : [];
     case 'task':
-      return buildTaskActions(result.taskRoute);
+      return buildTaskActions(result.taskRoute, ctx);
     default:
       return [];
   }
 }
 
-function buildTaskActions(taskRoute) {
+function buildTaskActions(taskRoute, ctx = {}) {
   if (!taskRoute) return [];
   if (taskRoute.escalateForConfirm) {
     const reason = (taskRoute.warnings && taskRoute.warnings[0]) || '입력이 모호합니다';
@@ -72,5 +79,13 @@ function buildTaskActions(taskRoute) {
 
   const intent = taskRoute.taskType === 'code' && taskRoute.intent ? ` (${taskRoute.intent})` : '';
 
-  return [`${messages[taskRoute.taskType] || '작업으로 분류됨'}${intent}`];
+  const actions = [`${messages[taskRoute.taskType] || '작업으로 분류됨'}${intent}`];
+
+  if (ctx.needsProjectSetup) {
+    actions.push(
+      '활성 프로젝트가 없습니다. /gv-init 으로 폴더 + (선택) GitHub repo + Good Vibe 프로젝트를 한 번에 셋업하세요',
+    );
+  }
+
+  return actions;
 }

--- a/scripts/handlers/infra.js
+++ b/scripts/handlers/infra.js
@@ -7,6 +7,7 @@ import {
   requireArray,
   requireOneOf,
   assertWithinRoot,
+  inputError,
 } from '../lib/core/validators.js';
 import { setupProjectInfra, appendToClaudeMd } from '../lib/project/project-scaffolder.js';
 import { checkGhStatus, createGithubRepo, gitInitAndPush } from '../lib/project/github-manager.js';
@@ -43,6 +44,7 @@ import { loadPreset, mergePresets } from '../lib/core/preset-loader.js';
 import { safeWriteFile, ensureDir } from '../lib/core/file-writer.js';
 import { claudeDir } from '../lib/core/app-paths.js';
 import { installShortcuts, uninstallShortcuts } from '../lib/core/shortcuts-installer.js';
+import { initProject, slugifyName } from '../lib/project/project-initializer.js';
 import { resolve } from 'path';
 import { homedir } from 'os';
 
@@ -288,5 +290,42 @@ export const commands = {
     if (data.targetDir) assertWithinRoot(targetDir, homedir(), 'targetDir');
     const result = await uninstallShortcuts({ targetDir });
     outputOk(result);
+  },
+
+  'init-project': async () => {
+    const data = await readStdin();
+    requireFields(data, ['name', 'targetDir']);
+    const target = resolve(data.targetDir);
+    assertWithinRoot(target, homedir(), 'targetDir');
+    // GitHub 옵션이면 핸들러 레벨에서 인증 사전 검증 (CLI 직접 호출 시에도 보호).
+    if (data.github === 'private' || data.github === 'public') {
+      const status = checkGhStatus();
+      if (!status.installed) {
+        throw inputError(
+          'gh CLI 가 설치되지 않았습니다. github=none 으로 진행하거나 gh 를 먼저 설치하세요',
+        );
+      }
+      if (!status.authenticated) {
+        throw inputError(
+          'gh 인증이 필요합니다. `gh auth login` 후 재시도하거나 github=none 으로 진행하세요',
+        );
+      }
+    }
+    const result = await initProject({
+      name: data.name,
+      type: data.type,
+      description: data.description,
+      targetDir: target,
+      techStack: data.techStack,
+      github: data.github,
+      mode: data.mode,
+    });
+    outputOk(result);
+  },
+
+  'slugify-name': async () => {
+    const data = await readStdin();
+    requireFields(data, ['name']);
+    output({ slug: slugifyName(data.name) });
   },
 };

--- a/scripts/lib/core/shortcuts-installer.js
+++ b/scripts/lib/core/shortcuts-installer.js
@@ -48,6 +48,12 @@ export const SHORTCUT_DEFINITIONS = [
     description: 'Good Vibe 상태/진행 조회',
   },
   {
+    name: 'gv-init',
+    targetSkill: 'good-vibe:gv-init',
+    description: 'Good Vibe 신규 프로젝트 셋업 — 폴더 + (선택) GitHub repo + 프로젝트 엔트리',
+    argumentHint: '[프로젝트 이름]',
+  },
+  {
     name: 'gv-execute',
     targetSkill: 'good-vibe:gv-execute',
     description: 'Good Vibe 실행 시작 — task-graph 진입점',

--- a/scripts/lib/project/project-initializer.js
+++ b/scripts/lib/project/project-initializer.js
@@ -1,0 +1,108 @@
+/**
+ * project-initializer — 신규 프로젝트 통합 셋업.
+ *
+ * 폴더 scaffold + 옵션 GitHub repo 생성/push + Good Vibe 프로젝트 엔트리 생성을 한 번에 묶어
+ * `/gv-init` 흐름과 SDK 양쪽에서 동일한 진입점을 제공한다. GitHub 단계는 부분 실패하더라도
+ * 로컬 프로젝트는 유지하고 warnings 배열에 사유를 기록한다.
+ */
+
+import { setupProjectInfra } from './project-scaffolder.js';
+import { createGithubRepo, gitInitAndPush } from './github-manager.js';
+import { createProject } from './project-manager.js';
+import { inputError } from '../core/validators.js';
+
+const VALID_GITHUB = ['none', 'private', 'public'];
+
+/**
+ * 프로젝트 이름을 슬러그로 변환한다.
+ * 한글/특수문자 제거 → 공백/구분자 → 하이픈 → 연속 하이픈 정규화.
+ * @param {string} name - 프로젝트 이름
+ * @returns {string} 슬러그 (빈 입력은 'untitled-project')
+ */
+export function slugifyName(name) {
+  if (!name || typeof name !== 'string') return 'untitled-project';
+  const slug = name
+    .toLowerCase()
+    .replace(/[^\u0061-\u007a\u0030-\u0039]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  // 한글/이모지/CJK 만 있는 입력은 ASCII 정제 후 빈 문자열이 되거나
+  // 의미 없는 1글자만 남을 수 있어 폴백 처리.
+  return slug.length >= 2 ? slug : 'untitled-project';
+}
+
+/**
+ * 신규 프로젝트를 한 번에 셋업한다.
+ * @param {object} opts
+ * @param {string} opts.name - 프로젝트 이름 (필수)
+ * @param {string} opts.targetDir - 폴더 절대 경로 (필수)
+ * @param {string} [opts.type='cli-tool'] - 프로젝트 유형
+ * @param {string} [opts.description] - 설명
+ * @param {string} [opts.techStack] - 기술 스택 힌트 (scaffold에 전달)
+ * @param {'none'|'private'|'public'} [opts.github='none'] - GitHub repo 옵션
+ * @param {string} [opts.mode] - Good Vibe 모드 (plan-only/plan-execute/quick-build)
+ * @returns {Promise<{projectId, project, infraPath, githubUrl, files, ci, warnings}>}
+ */
+export async function initProject(opts = {}) {
+  const {
+    name,
+    type = 'cli-tool',
+    description,
+    targetDir,
+    techStack,
+    github = 'none',
+    mode,
+  } = opts;
+
+  if (!name) throw inputError('name이 필요합니다');
+  if (!targetDir) throw inputError('targetDir이 필요합니다');
+  if (!VALID_GITHUB.includes(github)) {
+    throw inputError(`github은 ${VALID_GITHUB.join(' / ')} 중 하나여야 합니다`);
+  }
+
+  const warnings = [];
+
+  const infraResult = await setupProjectInfra({
+    name,
+    description,
+    techStack: techStack || type,
+    targetDir,
+    mode,
+  });
+
+  let githubUrl = null;
+  if (github === 'private' || github === 'public') {
+    const repoSlug = slugifyName(name);
+    // createGithubRepo / gitInitAndPush 는 execFileSync 기반 동기 함수 (github-manager.js).
+    // 의도적으로 await 없음.
+    const repoResult = createGithubRepo(repoSlug, {
+      visibility: github,
+      description,
+    });
+    if (repoResult.success) {
+      githubUrl = repoResult.url;
+      const pushResult = gitInitAndPush(infraResult.projectDir, githubUrl);
+      if (!pushResult.success) {
+        warnings.push(`git push 실패: ${pushResult.error || '알 수 없음'}`);
+      }
+    } else {
+      warnings.push(`GitHub repo 생성 실패: ${repoResult.error || '알 수 없음'}`);
+    }
+  }
+
+  const project = await createProject(name, type, description, {
+    mode,
+    infraPath: infraResult.projectDir,
+    githubUrl,
+  });
+
+  return {
+    projectId: project.id,
+    project,
+    infraPath: infraResult.projectDir,
+    githubUrl,
+    files: infraResult.files,
+    ci: infraResult.ci,
+    warnings,
+  };
+}

--- a/tests/handlers/dispatch.test.js
+++ b/tests/handlers/dispatch.test.js
@@ -93,4 +93,42 @@ describe('handlers/dispatch — gv-dispatch', () => {
       expect(statusResult.taskRoute).toBeNull();
     });
   });
+
+  describe('needsProjectSetup 플래그 (코드 task + 프로젝트 없음)', () => {
+    it('코드 task + hasProject=false → needsProjectSetup=true + /gv-init 안내', () => {
+      const r = cliExec('gv-dispatch', { input: '결제 시스템 구현해줘', hasProject: false });
+      expect(r.category).toBe('task');
+      expect(r.taskRoute.taskType).toBe('code');
+      expect(r.needsProjectSetup).toBe(true);
+      expect(r.nextActions.join(' ')).toMatch(/gv-init/);
+    });
+
+    it('코드 task + hasProject=true → needsProjectSetup=false', () => {
+      const r = cliExec('gv-dispatch', { input: '결제 시스템 구현해줘', hasProject: true });
+      expect(r.needsProjectSetup).toBe(false);
+      expect(r.nextActions.join(' ')).not.toMatch(/gv-init/);
+    });
+
+    it('research task → needsProjectSetup=false (코드/기획 아님)', () => {
+      const r = cliExec('gv-dispatch', { input: 'BullMQ vs Temporal 비교', hasProject: false });
+      expect(r.taskRoute.taskType).toBe('research');
+      expect(r.needsProjectSetup).toBe(false);
+    });
+
+    it('plan task + hasProject=false → needsProjectSetup=true (대형 기획도 신규 프로젝트)', () => {
+      const r = cliExec('gv-dispatch', {
+        input: '마이크로서비스 SaaS 플랫폼 만들고 싶어',
+        hasProject: false,
+      });
+      expect(r.taskRoute.taskType).toBe('plan');
+      expect(r.needsProjectSetup).toBe(true);
+      expect(r.nextActions.join(' ')).toMatch(/gv-init/);
+    });
+
+    it('escalate 입력 → needsProjectSetup=false (모호하므로 setup 권유 안 함)', () => {
+      const r = cliExec('gv-dispatch', { input: '', hasProject: false });
+      expect(r.taskRoute.escalateForConfirm).toBe(true);
+      expect(r.needsProjectSetup).toBe(false);
+    });
+  });
 });

--- a/tests/handlers/init-project.test.js
+++ b/tests/handlers/init-project.test.js
@@ -1,0 +1,105 @@
+/**
+ * init-project + slugify-name 핸들러 E2E 테스트.
+ * github: 'none' 만 검증 (gh CLI 실행 회피). github 분기는 unit 에서 모킹됨.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdir, rm, readdir } from 'fs/promises';
+import { resolve } from 'path';
+
+const CLI_PATH = resolve('scripts/cli.js');
+const TMP_DIR = resolve('.tmp-test-init-project');
+const PROJECT_DIR = resolve(TMP_DIR, 'my-bot');
+
+beforeEach(async () => {
+  await rm(TMP_DIR, { recursive: true, force: true });
+  await mkdir(TMP_DIR, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(TMP_DIR, { recursive: true, force: true });
+});
+
+function exec(command, input) {
+  return JSON.parse(
+    execSync(`node ${CLI_PATH} ${command}`, {
+      input: input !== undefined ? JSON.stringify(input) : '',
+      encoding: 'utf-8',
+      timeout: 15_000,
+      env: { ...process.env, GOOD_VIBE_BASE_DIR: resolve(TMP_DIR, 'gv-store') },
+    }),
+  );
+}
+
+function execRaw(command, input) {
+  try {
+    const stdout = execSync(`node ${CLI_PATH} ${command}`, {
+      input: input !== undefined ? JSON.stringify(input) : '',
+      encoding: 'utf-8',
+      timeout: 15_000,
+      env: { ...process.env, GOOD_VIBE_BASE_DIR: resolve(TMP_DIR, 'gv-store') },
+    });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (err) {
+    return { exitCode: err.status, stdout: '', stderr: err.stderr || '' };
+  }
+}
+
+describe('handlers/infra — slugify-name E2E', () => {
+  it('이름 입력 → slug 반환', () => {
+    const r = exec('slugify-name', { name: 'My Cool Bot' });
+    expect(r.slug).toBe('my-cool-bot');
+  });
+
+  it('한글 포함 → 한글 제거 후 영문/숫자만', () => {
+    const r = exec('slugify-name', { name: 'AI 트렌딩 Bot 2026' });
+    expect(r.slug).toBe('ai-bot-2026');
+  });
+
+  it('name 누락 → INPUT_ERROR', () => {
+    const r = execRaw('slugify-name', {});
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/name/);
+  });
+});
+
+describe('handlers/infra — init-project E2E', () => {
+  it('github=none → 폴더 + Good Vibe 프로젝트 엔트리 생성', () => {
+    const r = exec('init-project', {
+      name: 'My Bot',
+      type: 'cli-tool',
+      description: '테스트 봇',
+      targetDir: PROJECT_DIR,
+      github: 'none',
+    });
+    expect(r.success).toBe(true);
+    expect(r.projectId).toBeTruthy();
+    expect(r.infraPath).toBe(PROJECT_DIR);
+    expect(r.githubUrl).toBeNull();
+    expect(r.warnings).toEqual([]);
+  });
+
+  it('생성된 폴더에 기본 scaffold 파일이 작성됨', async () => {
+    exec('init-project', {
+      name: 'My Bot',
+      type: 'cli-tool',
+      targetDir: PROJECT_DIR,
+      github: 'none',
+    });
+    const files = await readdir(PROJECT_DIR);
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('targetDir 누락 → INPUT_ERROR', () => {
+    const r = execRaw('init-project', { name: 'X' });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/targetDir/);
+  });
+
+  it('targetDir 이 homedir() 바깥 → INPUT_ERROR', () => {
+    const r = execRaw('init-project', { name: 'X', targetDir: '/etc/foo' });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/targetDir/);
+  });
+});

--- a/tests/handlers/shortcuts.test.js
+++ b/tests/handlers/shortcuts.test.js
@@ -44,13 +44,13 @@ function execRaw(command, input) {
 }
 
 describe('handlers/infra — install-shortcuts E2E', () => {
-  it('targetDir 지정 시 7개 파일을 작성하고 success 응답', async () => {
+  it('targetDir 지정 시 8개 파일을 작성하고 success 응답', async () => {
     const r = exec('install-shortcuts', { targetDir: TARGET_DIR });
     expect(r.success).toBe(true);
-    expect(r.installed).toHaveLength(7);
+    expect(r.installed).toHaveLength(8);
     expect(r.skipped).toHaveLength(0);
     const files = await readdir(TARGET_DIR);
-    expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(7);
+    expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(8);
   });
 
   it('각 래퍼는 description, targetSkill, $ARGUMENTS 포함', async () => {
@@ -65,7 +65,7 @@ describe('handlers/infra — install-shortcuts E2E', () => {
     exec('install-shortcuts', { targetDir: TARGET_DIR });
     const r2 = exec('install-shortcuts', { targetDir: TARGET_DIR });
     expect(r2.installed).toHaveLength(0);
-    expect(r2.skipped).toHaveLength(7);
+    expect(r2.skipped).toHaveLength(8);
     expect(r2.skipped[0].reason).toBe('already-installed');
   });
 
@@ -73,7 +73,7 @@ describe('handlers/infra — install-shortcuts E2E', () => {
     exec('install-shortcuts', { targetDir: TARGET_DIR });
     await writeFile(resolve(TARGET_DIR, 'gv.md'), 'tampered', 'utf-8');
     const r = exec('install-shortcuts', { targetDir: TARGET_DIR, force: true });
-    expect(r.installed).toHaveLength(7);
+    expect(r.installed).toHaveLength(8);
     const content = await readFile(resolve(TARGET_DIR, 'gv.md'), 'utf-8');
     expect(content).toContain('good-vibe:gv');
   });

--- a/tests/project-initializer.test.js
+++ b/tests/project-initializer.test.js
@@ -1,0 +1,177 @@
+/**
+ * project-initializer — 통합 셋업 (folder + optional GitHub + Good Vibe project entry).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../scripts/lib/project/project-scaffolder.js', () => ({
+  setupProjectInfra: vi.fn(),
+  appendToClaudeMd: vi.fn(),
+}));
+
+vi.mock('../scripts/lib/project/github-manager.js', () => ({
+  createGithubRepo: vi.fn(),
+  gitInitAndPush: vi.fn(),
+  checkGhStatus: vi.fn(),
+}));
+
+vi.mock('../scripts/lib/project/project-manager.js', () => ({
+  createProject: vi.fn(),
+}));
+
+import { setupProjectInfra } from '../scripts/lib/project/project-scaffolder.js';
+import { createGithubRepo, gitInitAndPush } from '../scripts/lib/project/github-manager.js';
+import { createProject } from '../scripts/lib/project/project-manager.js';
+import { initProject, slugifyName } from '../scripts/lib/project/project-initializer.js';
+
+describe('slugifyName', () => {
+  it('한글 + 영어 혼합을 슬러그로 변환 (한글은 제거됨)', () => {
+    expect(slugifyName('GitHub AI 트렌딩 봇')).toBe('github-ai');
+  });
+
+  it('영어 카멜케이스 + 공백', () => {
+    expect(slugifyName('My Cool Project')).toBe('my-cool-project');
+  });
+
+  it('빈 문자열 → 기본값 반환', () => {
+    expect(slugifyName('')).toBe('untitled-project');
+  });
+
+  it('특수문자 제거', () => {
+    expect(slugifyName('test/proj@v1!')).toBe('test-proj-v1');
+  });
+
+  it('연속 하이픈 정규화', () => {
+    expect(slugifyName('a -- b')).toBe('a-b');
+  });
+
+  it('한글/이모지만 있어 정제 후 짧으면 폴백', () => {
+    expect(slugifyName('🎯')).toBe('untitled-project');
+    expect(slugifyName('한글')).toBe('untitled-project');
+    expect(slugifyName('a')).toBe('untitled-project');
+  });
+});
+
+describe('initProject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupProjectInfra.mockResolvedValue({
+      files: [{ path: '/proj/package.json', written: true }],
+      projectDir: '/proj',
+      ci: null,
+    });
+    createProject.mockResolvedValue({
+      id: 'proj-123',
+      name: 'Test Project',
+      type: 'cli-tool',
+      status: 'planning',
+    });
+    createGithubRepo.mockReturnValue({
+      success: true,
+      url: 'https://github.com/me/test-project',
+      error: null,
+    });
+    gitInitAndPush.mockReturnValue({ success: true, error: null });
+  });
+
+  it('GitHub 없이 로컬만 셋업', async () => {
+    const result = await initProject({
+      name: 'Test Project',
+      type: 'cli-tool',
+      description: 'desc',
+      targetDir: '/proj',
+      github: 'none',
+    });
+    expect(setupProjectInfra).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Test Project', targetDir: '/proj' }),
+    );
+    expect(createGithubRepo).not.toHaveBeenCalled();
+    expect(gitInitAndPush).not.toHaveBeenCalled();
+    expect(createProject).toHaveBeenCalledWith(
+      'Test Project',
+      'cli-tool',
+      'desc',
+      expect.objectContaining({ infraPath: '/proj', githubUrl: null }),
+    );
+    expect(result.githubUrl).toBeNull();
+    expect(result.projectId).toBe('proj-123');
+    expect(result.infraPath).toBe('/proj');
+  });
+
+  it('GitHub private 옵션 → repo 생성 + push 진행', async () => {
+    const result = await initProject({
+      name: 'Test Project',
+      type: 'cli-tool',
+      description: 'desc',
+      targetDir: '/proj',
+      github: 'private',
+    });
+    expect(createGithubRepo).toHaveBeenCalledWith(
+      'test-project',
+      expect.objectContaining({ visibility: 'private', description: 'desc' }),
+    );
+    expect(gitInitAndPush).toHaveBeenCalledWith('/proj', 'https://github.com/me/test-project');
+    expect(result.githubUrl).toBe('https://github.com/me/test-project');
+  });
+
+  it('GitHub public 옵션 → visibility=public 전달', async () => {
+    await initProject({
+      name: 'Public Project',
+      type: 'cli-tool',
+      targetDir: '/proj',
+      github: 'public',
+    });
+    expect(createGithubRepo).toHaveBeenCalledWith(
+      'public-project',
+      expect.objectContaining({ visibility: 'public' }),
+    );
+  });
+
+  it('GitHub repo 생성 실패 → 로컬은 유지하고 githubUrl=null + warning 포함', async () => {
+    createGithubRepo.mockReturnValue({
+      success: false,
+      url: null,
+      error: 'name already exists',
+    });
+    const result = await initProject({
+      name: 'Test Project',
+      targetDir: '/proj',
+      github: 'private',
+    });
+    expect(result.githubUrl).toBeNull();
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringMatching(/GitHub repo 생성 실패/)]),
+    );
+    expect(createProject).toHaveBeenCalled(); // 프로젝트는 여전히 생성
+    expect(gitInitAndPush).not.toHaveBeenCalled();
+  });
+
+  it('git push 실패 → repo URL은 유지 + push 실패 warning', async () => {
+    gitInitAndPush.mockReturnValue({ success: false, error: 'permission denied' });
+    const result = await initProject({
+      name: 'Test Project',
+      targetDir: '/proj',
+      github: 'private',
+    });
+    expect(result.githubUrl).toBe('https://github.com/me/test-project');
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.stringMatching(/git push 실패/)]),
+    );
+  });
+
+  it('필수 필드 누락 → throw', async () => {
+    await expect(initProject({ targetDir: '/proj' })).rejects.toThrow(/name/);
+    await expect(initProject({ name: 'X' })).rejects.toThrow(/targetDir/);
+  });
+
+  it('잘못된 github 옵션 → throw', async () => {
+    await expect(initProject({ name: 'X', targetDir: '/proj', github: 'invalid' })).rejects.toThrow(
+      /github/,
+    );
+  });
+
+  it('type 기본값 = "cli-tool"', async () => {
+    await initProject({ name: 'X', targetDir: '/proj' });
+    expect(createProject).toHaveBeenCalledWith('X', 'cli-tool', undefined, expect.any(Object));
+  });
+});

--- a/tests/shortcuts-installer.test.js
+++ b/tests/shortcuts-installer.test.js
@@ -21,8 +21,8 @@ describe('shortcuts-installer', () => {
   });
 
   describe('SHORTCUT_DEFINITIONS', () => {
-    it('7개 단축어를 정의해야 한다', () => {
-      expect(SHORTCUT_DEFINITIONS).toHaveLength(7);
+    it('8개 단축어를 정의해야 한다', () => {
+      expect(SHORTCUT_DEFINITIONS).toHaveLength(8);
     });
 
     it('각 단축어는 name, targetSkill, description 필드를 가져야 한다', () => {
@@ -40,6 +40,7 @@ describe('shortcuts-installer', () => {
         expect.arrayContaining([
           'gv',
           'gv-status',
+          'gv-init',
           'gv-execute',
           'gv-resume',
           'gv-team',
@@ -94,26 +95,26 @@ describe('shortcuts-installer', () => {
   });
 
   describe('installShortcuts', () => {
-    it('지정 디렉토리에 7개 파일을 작성해야 한다', async () => {
+    it('지정 디렉토리에 8개 파일을 작성해야 한다', async () => {
       const result = await installShortcuts({ targetDir: TMP_DIR });
-      expect(result.installed).toHaveLength(7);
+      expect(result.installed).toHaveLength(8);
       expect(result.skipped).toHaveLength(0);
       const files = await readdir(TMP_DIR);
-      expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(7);
+      expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(8);
     });
 
     it('targetDir이 없으면 자동 생성해야 한다', async () => {
       const nestedDir = resolve(TMP_DIR, 'nested', 'commands');
       await installShortcuts({ targetDir: nestedDir });
       const files = await readdir(nestedDir);
-      expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(7);
+      expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(8);
     });
 
     it('이미 같은 단축어가 존재하면 skip 한다 (멱등성)', async () => {
       await installShortcuts({ targetDir: TMP_DIR });
       const result = await installShortcuts({ targetDir: TMP_DIR });
       expect(result.installed).toHaveLength(0);
-      expect(result.skipped).toHaveLength(7);
+      expect(result.skipped).toHaveLength(8);
     });
 
     it('force=true 면 기존 파일을 덮어쓴다', async () => {
@@ -121,7 +122,7 @@ describe('shortcuts-installer', () => {
       const filePath = resolve(TMP_DIR, 'gv.md');
       await writeFile(filePath, 'modified', 'utf-8');
       const result = await installShortcuts({ targetDir: TMP_DIR, force: true });
-      expect(result.installed).toHaveLength(7);
+      expect(result.installed).toHaveLength(8);
       const content = await readFile(filePath, 'utf-8');
       expect(content).toContain('good-vibe:gv');
     });
@@ -134,15 +135,15 @@ describe('shortcuts-installer', () => {
       expect(result.skipped).toContainEqual(
         expect.objectContaining({ name: 'gv', reason: 'conflict' }),
       );
-      expect(result.installed.length).toBeLessThan(7);
+      expect(result.installed.length).toBeLessThan(8);
     });
   });
 
   describe('uninstallShortcuts', () => {
-    it('우리가 설치한 7개 파일만 제거한다', async () => {
+    it('우리가 설치한 8개 파일만 제거한다', async () => {
       await installShortcuts({ targetDir: TMP_DIR });
       const result = await uninstallShortcuts({ targetDir: TMP_DIR });
-      expect(result.removed).toHaveLength(7);
+      expect(result.removed).toHaveLength(8);
       const files = await readdir(TMP_DIR);
       expect(files.filter((f) => f.endsWith('.md'))).toHaveLength(0);
     });


### PR DESCRIPTION
## Summary

- `/gv-init` 슬래시 추가 — AskUserQuestion 위자드 + gh 인증 상태 분기 + `init-project` CLI 1회 호출로 신규 프로젝트 셋업 완료
- `init-project` CLI — `setupProjectInfra` + (선택) `createGithubRepo` + `gitInitAndPush` + `createProject` 를 묶은 통합 진입점
- `gv-dispatch` 응답에 `needsProjectSetup` 플래그 + `/gv-init` nextAction 자동 안내 (code/plan task + 활성 프로젝트 없음)
- 단축어 8개로 확장 (`gv-init` 추가)

## Why

- 신규 프로젝트는 폴더/repo 셋업이 `/gv-execute` 진입 전에 필요. 기존 흐름은 사용자가 수동 `mkdir` + `gh repo create` + `setup-project-infra` 를 따로 호출해야 함
- gh 인증 상태에 따라 선택지가 달라야 자연스러움 (인증 안 되면 GitHub 옵션 자체를 보여주지 않음)
- 부분 실패(repo 이름 충돌, push 실패) 시 로컬 프로젝트는 유지하고 `warnings` 배열에 사유 기록 → 작업 손실 없음

## 핵심 설계

- **WizardSeparation**: 슬래시(`commands/gv-init.md`)는 사용자 입력 수집만, 실제 셋업은 `init-project` CLI 1회로 위임 (Thin Controller 원칙)
- **Auth 분기 이중화**: `commands/gv-init.md` 위자드에서 1차 + `init-project` 핸들러에서 2차 (`checkGhStatus`) — CLI 직접 호출 시에도 보호
- **slugifyName 폴백**: 한글/이모지/CJK 입력 정제 후 짧으면 `'untitled-project'` 반환 (length < 2 폴백)
- **Partial-failure 회복**: `createGithubRepo` / `gitInitAndPush` 실패해도 로컬 infra + Good Vibe 프로젝트는 유지, `warnings` 배열에 사유 기록
- **needsProjectSetup**: `code` 또는 `plan` task + `hasProject=false` + non-escalate 일 때 true

## 변경 파일

신규:
- `scripts/lib/project/project-initializer.js` — `initProject()` + `slugifyName()`
- `commands/gv-init.md` — 슬래시 커맨드 위자드
- `tests/project-initializer.test.js` — 14 unit
- `tests/handlers/init-project.test.js` — 7 E2E

수정:
- `scripts/handlers/infra.js` — `init-project`, `slugify-name` 핸들러 + gh 인증 사전 검증
- `scripts/handlers/dispatch.js` — `needsProjectSetup` 플래그 + nextActions 안내
- `scripts/handlers/dispatch.test.js` — 4 추가 케이스
- `scripts/cli.js` — COMMAND_MAP 등록
- `scripts/lib/core/shortcuts-installer.js` — `gv-init` 단축어 추가 (총 8개)
- `tests/shortcuts-installer.test.js`, `tests/handlers/shortcuts.test.js` — 카운트 갱신
- `README.md` — 단축어 사용 예시에 `/gv-init` 추가
- `CHANGELOG.md` — 2.0.0-rc.4 엔트리
- `package.json` / `plugin.json` / `marketplace.json` — version bump

## Test plan

- [x] `npx vitest run tests/project-initializer.test.js tests/handlers/init-project.test.js tests/handlers/dispatch.test.js tests/shortcuts-installer.test.js tests/handlers/shortcuts.test.js` — 60/60
- [x] `npm test` — 3088/3088 (2 skipped) 통과
- [x] `npm run lint` — clean
- [x] code-reviewer-kr 리뷰: Critical 1 (false-positive, 주석 추가), Warning 3 (2건 반영, 1건 follow-up), Suggestion 1 (반영)
- [ ] 머지 후 플러그인 캐시 갱신 → 신규 프로젝트 흐름 직접 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)