### PR TITLE
fix(gemini-bridge): 새 Gemini CLI 호환성 + default model 갱신

### DIFF
--- a/scripts/lib/llm/gemini-bridge.js
+++ b/scripts/lib/llm/gemini-bridge.js
@@ -28,7 +28,7 @@ export const _installCache = new Map();
  * @returns {{ text: string, provider: string, model: string, tokenCount: number }}
  */
 export function parseGeminiCliOutput(stdout, model) {
-  const fallbackModel = model || 'gemini-2.0-flash';
+  const fallbackModel = model || 'gemini-2.5-flash';
 
   if (!stdout || stdout.trim() === '') {
     return { text: '', provider: 'gemini', model: fallbackModel, tokenCount: 0 };
@@ -90,7 +90,7 @@ export function isGeminiCliInstalled(cliPath) {
  */
 export function callGeminiCli(prompt, options = {}) {
   const cliPath = options.cliPath || DEFAULT_CLI_PATH;
-  const model = options.model || 'gemini-2.0-flash';
+  const model = options.model || 'gemini-2.5-flash';
   const timeout = options.timeout || DEFAULT_TIMEOUT_MS;
 
   if (!isGeminiCliInstalled(cliPath)) {
@@ -99,10 +99,15 @@ export function callGeminiCli(prompt, options = {}) {
     );
   }
 
-  const args = ['-p', prompt, '-o', 'json', '-m', model];
+  // 새 버전 Gemini CLI(>=0.x)는 -p 플래그 + positional prompt 충돌하고,
+  // Windows cmd.exe(shell: true)는 빈 문자열/공백 인수를 손실시킨다.
+  // 해결: stdin이 TTY가 아니면 gemini가 자동으로 non-interactive 모드 진입하므로
+  // -p 플래그를 제거하고 prompt를 stdin으로만 전달한다 (Linux/macOS/Windows 공통).
+  const args = ['-o', 'json', '-m', model];
   const result = spawnSync(cliPath, args, {
     timeout,
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: ['pipe', 'pipe', 'pipe'],
+    input: prompt,
     encoding: 'utf-8',
     maxBuffer: 10 * 1024 * 1024,
     shell: IS_WINDOWS,

--- a/scripts/lib/llm/llm-provider.js
+++ b/scripts/lib/llm/llm-provider.js
@@ -36,7 +36,7 @@ const PROVIDER_ENDPOINTS = {
 const DEFAULT_MODELS = {
   claude: 'claude-sonnet-4-6',
   openai: 'gpt-4o',
-  gemini: 'gemini-2.0-flash',
+  gemini: 'gemini-2.5-flash',
 };
 
 /** 지원 프로바이더 목록 */

--- a/tests/gemini-bridge.test.js
+++ b/tests/gemini-bridge.test.js
@@ -22,7 +22,7 @@ describe('parseGeminiCliOutput', () => {
       },
     });
 
-    const result = parseGeminiCliOutput(stdout, 'gemini-2.0-flash');
+    const result = parseGeminiCliOutput(stdout, 'gemini-2.5-flash');
     expect(result.text).toBe('리뷰 결과입니다.');
     expect(result.provider).toBe('gemini');
     expect(result.model).toBe('gemini-2.5-flash');
@@ -32,23 +32,23 @@ describe('parseGeminiCliOutput', () => {
   it('stats가 없는 응답을 처리한다', () => {
     const stdout = JSON.stringify({ response: '간단한 응답' });
 
-    const result = parseGeminiCliOutput(stdout, 'gemini-2.0-flash');
+    const result = parseGeminiCliOutput(stdout, 'gemini-2.5-flash');
     expect(result.text).toBe('간단한 응답');
     expect(result.provider).toBe('gemini');
-    expect(result.model).toBe('gemini-2.0-flash');
+    expect(result.model).toBe('gemini-2.5-flash');
     expect(result.tokenCount).toBe(0);
   });
 
   it('빈 stdout을 처리한다', () => {
-    const result = parseGeminiCliOutput('', 'gemini-2.0-flash');
+    const result = parseGeminiCliOutput('', 'gemini-2.5-flash');
     expect(result.text).toBe('');
     expect(result.provider).toBe('gemini');
-    expect(result.model).toBe('gemini-2.0-flash');
+    expect(result.model).toBe('gemini-2.5-flash');
     expect(result.tokenCount).toBe(0);
   });
 
   it('null stdout을 처리한다', () => {
-    const result = parseGeminiCliOutput(null, 'gemini-2.0-flash');
+    const result = parseGeminiCliOutput(null, 'gemini-2.5-flash');
     expect(result.text).toBe('');
     expect(result.provider).toBe('gemini');
     expect(result.tokenCount).toBe(0);
@@ -57,17 +57,17 @@ describe('parseGeminiCliOutput', () => {
   it('JSON이 아닌 raw 텍스트를 fallback 처리한다', () => {
     const stdout = 'This is plain text response from CLI';
 
-    const result = parseGeminiCliOutput(stdout, 'gemini-2.0-flash');
+    const result = parseGeminiCliOutput(stdout, 'gemini-2.5-flash');
     expect(result.text).toBe('This is plain text response from CLI');
     expect(result.provider).toBe('gemini');
-    expect(result.model).toBe('gemini-2.0-flash');
+    expect(result.model).toBe('gemini-2.5-flash');
     expect(result.tokenCount).toBe(0);
   });
 
   it('response 키가 없는 JSON을 처리한다', () => {
     const stdout = JSON.stringify({ data: 'something', stats: {} });
 
-    const result = parseGeminiCliOutput(stdout, 'gemini-2.0-flash');
+    const result = parseGeminiCliOutput(stdout, 'gemini-2.5-flash');
     expect(result.text).toBe('');
     expect(result.provider).toBe('gemini');
     expect(result.tokenCount).toBe(0);
@@ -79,7 +79,7 @@ describe('parseGeminiCliOutput', () => {
       stats: {
         models: {
           'gemini-2.5-pro': { tokens: { total: 500 } },
-          'gemini-2.0-flash': { tokens: { total: 200 } },
+          'gemini-2.5-flash': { tokens: { total: 200 } },
         },
       },
     });
@@ -94,7 +94,7 @@ describe('parseGeminiCliOutput', () => {
     const stdout = JSON.stringify({ response: '기본 모델 응답' });
 
     const result = parseGeminiCliOutput(stdout);
-    expect(result.model).toBe('gemini-2.0-flash');
+    expect(result.model).toBe('gemini-2.5-flash');
   });
 
   it('stats.models가 빈 객체일 때 처리한다', () => {
@@ -103,9 +103,9 @@ describe('parseGeminiCliOutput', () => {
       stats: { models: {} },
     });
 
-    const result = parseGeminiCliOutput(stdout, 'gemini-2.0-flash');
+    const result = parseGeminiCliOutput(stdout, 'gemini-2.5-flash');
     expect(result.text).toBe('빈 stats');
-    expect(result.model).toBe('gemini-2.0-flash');
+    expect(result.model).toBe('gemini-2.5-flash');
     expect(result.tokenCount).toBe(0);
   });
 
@@ -119,7 +119,7 @@ describe('parseGeminiCliOutput', () => {
       },
     });
 
-    const result = parseGeminiCliOutput(stdout, 'gemini-2.0-flash');
+    const result = parseGeminiCliOutput(stdout, 'gemini-2.5-flash');
     expect(result.text).toBe('no total');
     expect(result.model).toBe('gemini-2.5-flash');
     expect(result.tokenCount).toBe(0);
@@ -225,11 +225,14 @@ describe('callGeminiCli', () => {
       signal: null,
     });
 
-    callGeminiCli('테스트 프롬프트', { model: 'gemini-2.0-flash', cliPath: '/custom/gemini' });
+    callGeminiCli('테스트 프롬프트', { model: 'gemini-2.5-flash', cliPath: '/custom/gemini' });
 
     const callArgs = vi.mocked(spawnSync).mock.calls[1];
     expect(callArgs[0]).toBe('/custom/gemini');
-    expect(callArgs[1]).toEqual(['-p', '테스트 프롬프트', '-o', 'json', '-m', 'gemini-2.0-flash']);
+    // 새 Gemini CLI 호환: prompt는 stdin으로, -p는 빈 문자열로 non-interactive 트리거만
+    expect(callArgs[1]).toEqual(['-o', 'json', '-m', 'gemini-2.5-flash']);
+    expect(callArgs[2].input).toBe('테스트 프롬프트');
+    expect(callArgs[2].stdio).toEqual(['pipe', 'pipe', 'pipe']);
   });
 
   it('CLI 미설치 시 에러를 던진다', () => {
@@ -303,7 +306,7 @@ describe('callGeminiCli', () => {
     callGeminiCli('기본값 테스트');
 
     const callArgs = vi.mocked(spawnSync).mock.calls[1];
-    expect(callArgs[1]).toContain('gemini-2.0-flash');
+    expect(callArgs[1]).toContain('gemini-2.5-flash');
     expect(callArgs[2].timeout).toBe(120000);
   });
 });
@@ -344,8 +347,9 @@ describe('callGeminiCli — 보안', () => {
     callGeminiCli(malicious);
 
     const callArgs = vi.mocked(spawnSync).mock.calls[1];
-    // args 배열로 전달 — shell 해석 안 함
-    expect(callArgs[1]).toContain(malicious);
+    // 새 호환 모드: prompt는 stdin input으로 전달 (shell이 절대 해석 안 함)
+    expect(callArgs[1]).not.toContain(malicious);
+    expect(callArgs[2].input).toBe(malicious);
     // Windows에서는 .cmd 래퍼 인식을 위해 shell: true 허용 (args 배열이므로 injection 안전)
     if (process.platform === 'win32') {
       expect(callArgs[2].shell).toBe(true);


### PR DESCRIPTION
## Summary

새 Gemini CLI(>=0.x)와의 호환성 회복 + deprecated 모델 ID 갱신.

## 문제

1. **`-p` + positional prompt 충돌**: 새 Gemini CLI는 `-p prompt`와 positional prompt를 동시 사용 시 `Cannot use both a positional prompt and the --prompt (-p) flag together` 에러 발생. `shell: true`(Windows .cmd 호환)에서 prompt에 공백이 있으면 cmd.exe가 일부를 positional로 분리해 충돌.
2. **빈 인수 손실**: 임시방편으로 `-p ''` 또는 `-p ' '`를 시도해도 cmd.exe가 빈 문자열/공백 단일 인수를 삭제 → `Not enough arguments following: p` 에러.
3. **Default model deprecated**: `gemini-2.0-flash`는 404 `ModelNotFoundError: Requested entity was not found.` 반환.

결과: `verify-provider --provider gemini`, `cross-model-review`, `gemini-review` 모두 실패.

## 해결

- **callGeminiCli**: `-p` 플래그를 완전히 제거하고 prompt를 stdin으로만 전달. stdin이 TTY가 아니면 gemini CLI가 자동으로 non-interactive 모드 진입 (Linux/macOS/Windows 공통). shell injection도 args 격리로 안전.
- **DEFAULT_MODELS.gemini**: `gemini-2.0-flash` → `gemini-2.5-flash` (현재 활성 모델).
- **테스트 갱신**: args 배열에서 prompt 제거 검증, `options.input`에 prompt 전달 검증, 보안 테스트는 prompt가 stdin으로 격리됨을 확인.

## 검증

- `verify-provider --provider gemini` → `connected: true, model: gemini-2.5-flash`
- 단위 테스트: `tests/gemini-bridge.test.js` 22 PASS
- 전체 테스트: 144 파일 / **3108 PASS**
- ESLint: 0 errors

## Test plan

- [x] `npm test` 144/144 PASS
- [x] `npm run lint` 0 errors
- [x] 실제 gemini CLI ping → connected: true
- [ ] CI 그린 (PR 생성 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)