### PR TITLE
feat(plan-only): provider 옵션 추가 — claude 외 LLM provider 지원

### DIFF
--- a/scripts/handlers/gv-execute.js
+++ b/scripts/handlers/gv-execute.js
@@ -54,6 +54,7 @@ async function runActiveFlow(data, project, events, journalCb) {
   const result = await runActiveProjectFlow(project, {
     useLLM,
     callLLM: useLLM ? callLLMWithFallback : undefined,
+    provider: data.provider,
     journal: journalCb,
     maxRounds: data.maxRounds,
   });

--- a/scripts/lib/engine/plan-only-runner.js
+++ b/scripts/lib/engine/plan-only-runner.js
@@ -41,14 +41,18 @@ async function ensureTeam(project) {
   return team;
 }
 
-async function callOrPlaceholder({ useLLM, callLLM }, prompt, options, placeholderText) {
+async function callOrPlaceholder({ useLLM, callLLM, provider }, prompt, options, placeholderText) {
   if (!useLLM) return placeholderText;
   const isObj = prompt && typeof prompt === 'object';
   const userText = isObj ? prompt.user : prompt;
   const systemText = isObj ? prompt.system : undefined;
-  const result = await callLLM(DEFAULT_PROVIDER, userText, {
+  const usedProvider = provider || DEFAULT_PROVIDER;
+  // member.model은 buildTeam에서 claude tier ID(opus/sonnet/haiku)로 할당됨.
+  // claude 외 provider 호출 시 모델 ID가 호환되지 않으므로 provider default 사용.
+  const passModel = usedProvider === 'claude' ? options.model : undefined;
+  const result = await callLLM(usedProvider, userText, {
     systemMessage: systemText,
-    model: options.model,
+    model: passModel,
   });
   return result.text;
 }
@@ -119,19 +123,21 @@ async function runReviews(team, synthesis, round, ctx) {
  * @param {object} [opts]
  * @param {boolean} [opts.useLLM=false] - 실제 LLM 호출 여부
  * @param {Function} [opts.callLLM] - useLLM=true일 때 필수. (provider, prompt, options) → {text, model, ...}
+ * @param {string} [opts.provider] - LLM provider ('claude' | 'openai' | 'gemini'). 미지정 시 'claude'
  * @param {number} [opts.maxRounds] - 기본 config.convergence.maxRounds
  * @returns {Promise<{finalState: 'approved'|'maxRounds', rounds: number, converged: boolean, planDocument?: string}>}
  */
 export async function runPlanOnly(project, opts = {}) {
   const useLLM = opts.useLLM === true;
   const callLLM = opts.callLLM;
+  const provider = opts.provider;
   if (useLLM && typeof callLLM !== 'function') {
     throw inputError('useLLM=true이면 callLLM 함수를 주입해야 합니다');
   }
 
   const maxRounds = opts.maxRounds || config.convergence.maxRounds || 3;
   const team = await ensureTeam(project);
-  const ctx = { useLLM, callLLM };
+  const ctx = { useLLM, callLLM, provider };
 
   let round = 0;
   let previousSynthesis = '';

--- a/tests/plan-only-runner.test.js
+++ b/tests/plan-only-runner.test.js
@@ -195,3 +195,54 @@ describe('plan-only-runner — 엣지 케이스', () => {
     );
   });
 });
+
+describe('plan-only-runner — provider 옵션', () => {
+  it('opts.provider가 명시되면 callLLM에 그 provider로 호출한다', async () => {
+    const callLLM = vi.fn(async (provider) => {
+      if (provider !== 'gemini') throw new Error(`expected gemini, got ${provider}`);
+      return { text: JSON.stringify({ approved: true, feedback: 'ok', issues: [] }), model: 'g' };
+    });
+
+    const result = await runPlanOnly(baseProject, {
+      useLLM: true,
+      callLLM,
+      provider: 'gemini',
+    });
+
+    expect(result.finalState).toBe('approved');
+    // 모든 호출이 gemini로 갔는지 검증
+    for (const call of callLLM.mock.calls) {
+      expect(call[0]).toBe('gemini');
+    }
+  });
+
+  it('claude 외 provider면 callLLM의 model 옵션이 undefined로 전달된다', async () => {
+    const callLLM = vi.fn(async () => ({
+      text: JSON.stringify({ approved: true, feedback: 'ok', issues: [] }),
+      model: 'gemini-2.5-flash',
+    }));
+
+    await runPlanOnly(baseProject, {
+      useLLM: true,
+      callLLM,
+      provider: 'gemini',
+    });
+
+    for (const call of callLLM.mock.calls) {
+      expect(call[2].model).toBeUndefined();
+    }
+  });
+
+  it('provider 미지정 시 claude가 기본값', async () => {
+    const callLLM = vi.fn(async () => ({
+      text: JSON.stringify({ approved: true, feedback: 'ok', issues: [] }),
+      model: 'haiku',
+    }));
+
+    await runPlanOnly(baseProject, { useLLM: true, callLLM });
+
+    for (const call of callLLM.mock.calls) {
+      expect(call[0]).toBe('claude');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`plan-only-runner`가 `DEFAULT_PROVIDER='claude'`를 하드코딩해서, claude 인증이 없는 환경(Gemini/OpenAI만 인증된 경우)에서 useLLM=true 호출이 NOT_FOUND 에러로 실패하던 문제 수정.

## 변경

- `runPlanOnly(opts.provider)`: provider 옵션 추가. 미지정 시 claude 기본값(역호환).
- claude 외 provider 사용 시 `buildTeam`이 할당한 claude tier ID(opus/sonnet/haiku)는 호환되지 않으므로 `model`을 undefined로 전달해 provider default(예: `gemini-2.5-flash`) 사용.
- `gv-execute`: stdin `data.provider`를 mode-dispatcher로 통과.

## 검증

- 신규 테스트 3건 (provider 분기, model undefined, claude 기본값)
- 전체 **3111 PASS** / lint 0

## Test plan

- [x] `npm test` 144/144
- [x] `npm run lint` 0 errors
- [x] 단위 테스트로 provider 옵션 전달 확인
- [ ] CI 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)